### PR TITLE
[codex] Add embedded skills discovery commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,11 +225,14 @@ md2wechat doctor --json                    # API、草稿、上传或配置本�
 md2wechat prompts list --kind image --json # 图片 prompt 选择时使用
 md2wechat providers list --json            # 图片生成 provider 选择时使用
 md2wechat capabilities --json              # 版本、命令能力或行为边界不确定时使用
+md2wechat skills read md2wechat --json     # 读取当前二进制内置的 Agent SOP
 ```
 
 Agent 排版时应保持原始 Markdown 只读：把文章复制到临时 Markdown，按需用 `layout render` 插入少量模块，先 `layout validate`，再把临时稿交给 `convert`。只有用户明确要求时，才把生成稿保存到源文件旁边。
 
-所有命令加 `--json` 后 stdout 只输出 JSON envelope，适合脚本和 Agent 直接消费。
+`skills list/read` 用来发现并读取当前安装版本随二进制发布的 Agent skill，适合在 README、远程仓库或本地 skill 可能过期时先确认运行时 SOP。
+
+所有 discovery 命令加 `--json` 后 stdout 只输出 JSON envelope，适合脚本和 Agent 直接消费。
 
 ---
 

--- a/cmd/md2wechat/discovery.go
+++ b/cmd/md2wechat/discovery.go
@@ -325,7 +325,7 @@ func buildCapabilitiesData() (map[string]any, error) {
 			"convert", "inspect", "preview", "config", "write", "humanize", "upload_image",
 			"download_and_upload", "generate_image", "generate_cover", "generate_infographic", "create_draft",
 			"create_image_post", "test-draft", "providers", "themes",
-			"prompts", "layout", "brand", "doctor", "capabilities", "version",
+			"prompts", "layout", "skills", "brand", "doctor", "capabilities", "version",
 		},
 		"convert": map[string]any{
 			"default_mode":     "api",

--- a/cmd/md2wechat/discovery_test.go
+++ b/cmd/md2wechat/discovery_test.go
@@ -220,7 +220,7 @@ func TestBuildCapabilitiesDataKeepsConvertContractStableWithInspectAndPreview(t 
 	if !ok {
 		t.Fatalf("commands type = %T", data["commands"])
 	}
-	if !contains(commands, "inspect") || !contains(commands, "preview") || !contains(commands, "convert") {
+	if !contains(commands, "inspect") || !contains(commands, "preview") || !contains(commands, "convert") || !contains(commands, "skills") {
 		t.Fatalf("commands = %#v", commands)
 	}
 

--- a/cmd/md2wechat/main.go
+++ b/cmd/md2wechat/main.go
@@ -314,6 +314,7 @@ Examples:
 	rootCmd.AddCommand(providersCmd)
 	rootCmd.AddCommand(themesCmd)
 	rootCmd.AddCommand(promptsCmd)
+	rootCmd.AddCommand(skillsCmd)
 
 	// write command
 	rootCmd.AddCommand(writeCmd)

--- a/cmd/md2wechat/skills.go
+++ b/cmd/md2wechat/skills.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/geekjourneyx/md2wechat-skill/internal/assets"
+	"github.com/spf13/cobra"
+)
+
+const (
+	codeSkillsShown   = "SKILLS_SHOWN"
+	codeSkillNotFound = "SKILL_NOT_FOUND"
+)
+
+type skillSummary struct {
+	Name        string   `json:"name"`
+	Version     string   `json:"version"`
+	Description string   `json:"description"`
+	RiskLevel   string   `json:"risk_level"`
+	SideEffects []string `json:"side_effects"`
+	Source      string   `json:"source"`
+	ContentHash string   `json:"content_hash"`
+	ReadCommand string   `json:"read_command"`
+	Commands    []string `json:"commands"`
+}
+
+type skillDocument struct {
+	Metadata skillSummary `json:"metadata"`
+	Content  string       `json:"content"`
+}
+
+var embeddedSkillDefaults = map[string]skillSummary{
+	"md2wechat": {
+		Name:        "md2wechat",
+		Description: "Convert Markdown to WeChat Official Account HTML and drafts with discovery-first CLI commands.",
+		RiskLevel:   "side-effect-aware",
+		SideEffects: []string{
+			"read-only discovery for version, capabilities, skills, providers, themes, prompts, layout, doctor, and inspect",
+			"local file writes only when output, preview, conversion, writing, humanize, or image generation commands request artifacts",
+			"network or WeChat side effects only for image providers, uploads, draft creation, or explicit publish flags",
+		},
+		Source: "embedded",
+		Commands: []string{
+			"skills list",
+			"skills read md2wechat",
+			"capabilities",
+			"inspect",
+			"preview",
+			"convert",
+		},
+	},
+}
+
+var skillsCmd = &cobra.Command{
+	Use:   "skills",
+	Short: "Inspect embedded agent skills",
+}
+
+var skillsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List embedded agent skills",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		skills, err := listEmbeddedSkillSummaries()
+		if err != nil {
+			return wrapCLIError(codeError, err, err.Error())
+		}
+		responseSuccessWith(codeSkillsShown, "Skills shown", map[string]any{"skills": skills})
+		return nil
+	},
+}
+
+var skillsReadCmd = &cobra.Command{
+	Use:   "read <name>",
+	Short: "Read an embedded agent skill",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		skill, err := readEmbeddedSkill(args[0])
+		if err != nil {
+			return err
+		}
+		responseSuccessWith(codeSkillsShown, "Skill shown", map[string]any{"skill": skill})
+		return nil
+	},
+}
+
+func init() {
+	skillsCmd.AddCommand(skillsListCmd, skillsReadCmd)
+}
+
+func listEmbeddedSkillSummaries() ([]skillSummary, error) {
+	names, err := assets.ListBuiltinSkills()
+	if err != nil {
+		return nil, err
+	}
+
+	skills := make([]skillSummary, 0, len(names))
+	for _, name := range names {
+		content, err := assets.ReadBuiltinSkill(name)
+		if err != nil {
+			return nil, err
+		}
+		skills = append(skills, buildSkillSummary(name, content))
+	}
+	return skills, nil
+}
+
+func readEmbeddedSkill(name string) (skillDocument, error) {
+	resolved, err := resolveEmbeddedSkillName(name)
+	if err != nil {
+		return skillDocument{}, err
+	}
+
+	content, err := assets.ReadBuiltinSkill(resolved)
+	if err != nil {
+		return skillDocument{}, wrapCLIError(codeError, err, err.Error())
+	}
+
+	return skillDocument{
+		Metadata: buildSkillSummary(resolved, content),
+		Content:  string(content),
+	}, nil
+}
+
+func resolveEmbeddedSkillName(name string) (string, error) {
+	names, err := assets.ListBuiltinSkills()
+	if err != nil {
+		return "", wrapCLIError(codeError, err, err.Error())
+	}
+	for _, candidate := range names {
+		if strings.EqualFold(candidate, name) {
+			return candidate, nil
+		}
+	}
+	return "", newCLIErrorWithDetails(
+		codeSkillNotFound,
+		fmt.Sprintf("unknown embedded skill: %s", name),
+		map[string]any{"requested": name, "available": names},
+		[]string{"Run md2wechat skills list --json and choose a listed skill name."},
+	)
+}
+
+func buildSkillSummary(name string, content []byte) skillSummary {
+	summary, ok := embeddedSkillDefaults[name]
+	if !ok {
+		summary = skillSummary{
+			Name:        name,
+			Description: "Embedded agent skill",
+			RiskLevel:   "unknown",
+			Source:      "embedded",
+		}
+	}
+	hash := sha256.Sum256(content)
+	summary.Version = Version
+	summary.ContentHash = "sha256:" + hex.EncodeToString(hash[:])
+	summary.ReadCommand = fmt.Sprintf("md2wechat skills read %s --json", name)
+	return summary
+}

--- a/cmd/md2wechat/skills_test.go
+++ b/cmd/md2wechat/skills_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSkillsListCommandExposesEmbeddedSkillMetadata(t *testing.T) {
+	oldJSON, oldVersion := jsonOutput, Version
+	t.Cleanup(func() {
+		jsonOutput = oldJSON
+		Version = oldVersion
+	})
+
+	jsonOutput = true
+	Version = "1.2.3"
+
+	stdout := captureStdout(t, func() {
+		if err := skillsListCmd.RunE(skillsListCmd, nil); err != nil {
+			t.Fatalf("RunE() error = %v", err)
+		}
+	})
+
+	var response struct {
+		Success bool   `json:"success"`
+		Code    string `json:"code"`
+		Data    struct {
+			Skills []skillSummary `json:"skills"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout, &response); err != nil {
+		t.Fatalf("unmarshal response: %v\n%s", err, stdout)
+	}
+	if !response.Success || response.Code != codeSkillsShown {
+		t.Fatalf("unexpected response: %#v", response)
+	}
+
+	var found *skillSummary
+	for i := range response.Data.Skills {
+		if response.Data.Skills[i].Name == "md2wechat" {
+			found = &response.Data.Skills[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected md2wechat skill: %#v", response.Data.Skills)
+	}
+	if found.Version != "1.2.3" || found.Source != "embedded" || found.RiskLevel != "side-effect-aware" {
+		t.Fatalf("unexpected skill metadata: %#v", found)
+	}
+	if found.ReadCommand != "md2wechat skills read md2wechat --json" {
+		t.Fatalf("ReadCommand = %q", found.ReadCommand)
+	}
+	if !strings.HasPrefix(found.ContentHash, "sha256:") || len(found.ContentHash) != len("sha256:")+64 {
+		t.Fatalf("ContentHash = %q", found.ContentHash)
+	}
+	if len(found.SideEffects) == 0 || len(found.Commands) == 0 {
+		t.Fatalf("expected side effects and command hints: %#v", found)
+	}
+}
+
+func TestSkillsReadCommandReturnsEmbeddedSkillContent(t *testing.T) {
+	oldJSON, oldVersion := jsonOutput, Version
+	t.Cleanup(func() {
+		jsonOutput = oldJSON
+		Version = oldVersion
+	})
+
+	jsonOutput = true
+	Version = "2.0.0"
+
+	stdout := captureStdout(t, func() {
+		if err := skillsReadCmd.RunE(skillsReadCmd, []string{"md2wechat"}); err != nil {
+			t.Fatalf("RunE() error = %v", err)
+		}
+	})
+
+	var response struct {
+		Success bool   `json:"success"`
+		Code    string `json:"code"`
+		Data    struct {
+			Skill skillDocument `json:"skill"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout, &response); err != nil {
+		t.Fatalf("unmarshal response: %v\n%s", err, stdout)
+	}
+	if !response.Success || response.Code != codeSkillsShown {
+		t.Fatalf("unexpected response: %#v", response)
+	}
+	if response.Data.Skill.Metadata.Name != "md2wechat" || response.Data.Skill.Metadata.Version != "2.0.0" {
+		t.Fatalf("unexpected skill metadata: %#v", response.Data.Skill.Metadata)
+	}
+	if !strings.Contains(response.Data.Skill.Content, "# md2wechat CLI Skill") {
+		t.Fatalf("missing embedded skill title:\n%s", response.Data.Skill.Content)
+	}
+	if !strings.Contains(response.Data.Skill.Content, "md2wechat skills read md2wechat --json") {
+		t.Fatalf("missing self-read guidance:\n%s", response.Data.Skill.Content)
+	}
+}
+
+func TestReadEmbeddedSkillRejectsUnknownSkill(t *testing.T) {
+	_, err := readEmbeddedSkill("missing")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	cliErr, ok := extractCLIError(err)
+	if !ok {
+		t.Fatalf("expected cliError, got %T: %v", err, err)
+	}
+	if cliErr.Code != codeSkillNotFound {
+		t.Fatalf("Code = %q, want %q", cliErr.Code, codeSkillNotFound)
+	}
+	if cliErr.Details["requested"] != "missing" {
+		t.Fatalf("Details = %#v", cliErr.Details)
+	}
+}

--- a/docs/DISCOVERY.md
+++ b/docs/DISCOVERY.md
@@ -9,6 +9,7 @@
 对于 Agent、脚本或 CI，discovery 应服务于下一步决策，而不是每次任务都全量枚举。使用最小必要集合：
 
 - 版本、能力或行为不确定：`md2wechat version --json`、`md2wechat capabilities --json`
+- 当前安装版本的 Agent SOP 不确定：`md2wechat skills list --json`、`md2wechat skills read md2wechat --json`
 - API、草稿、上传或配置 readiness：`md2wechat doctor --json`，必要时再 `md2wechat config show --format json`
 - 文章排版且用户未指定主题或模块：`md2wechat themes list --json`、`md2wechat layout list --json`
 - 已指定某个资源：使用对应的 `providers show`、`themes show`、`prompts show` 或 `layout show`
@@ -30,6 +31,7 @@ md2wechat capabilities --json
 - 当前可枚举的 theme
 - 当前可枚举的 prompt catalog
 - `layout` catalog 是否可用、模块数量、schema version、是否仅 API 模式渲染
+- `skills` 命令是否可用，用于读取当前二进制内嵌的 Agent skill
 
 示例片段：
 
@@ -42,11 +44,26 @@ md2wechat capabilities --json
     "api_mode_only": true,
     "schema_version": "1"
   },
-  "commands": ["convert", "inspect", "preview", "layout", "themes"]
+  "commands": ["convert", "inspect", "preview", "layout", "themes", "skills"]
 }
 ```
 
 未出现在 `commands` 中的命令不应被 Agent 当成可执行能力。未来工作流不通过 `capabilities` 预告。
+
+## 内置 Agent Skills
+
+```bash
+md2wechat skills list --json
+md2wechat skills read md2wechat --json
+```
+
+`skills` 命令读取的是当前安装二进制内嵌的 skill，不依赖远程仓库、README 或本地外部 skill 目录。它适合 Agent 在以下情况下使用：
+
+- 安装版本未知，需要确认当前版本 SOP；
+- 本地 `skills/md2wechat/SKILL.md` 或远程仓库可能比二进制更新或更旧；
+- 自动化脚本需要拿到 `content_hash`、side effects、risk level 和可读 SOP 内容。
+
+`skills list --json` 返回摘要元数据；`skills read <name> --json` 返回同样的 metadata 加完整 `content`。这两个命令是只读 discovery，不会读取用户文章、上传图片或创建草稿。
 
 ## 本地体检
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -755,6 +755,7 @@ md2wechat config show --format json
 ```bash
 md2wechat config show --format json
 md2wechat capabilities --json
+md2wechat skills read md2wechat --json
 md2wechat providers list --json
 md2wechat providers show volcengine --json
 md2wechat themes list --json
@@ -764,6 +765,7 @@ md2wechat prompts list --json
 这样 Agent 才知道：
 
 - 当前配置用了哪份文件
+- 当前安装二进制内置的 Agent SOP 是什么
 - 默认 provider 是什么
 - 当前 provider 支持哪些模型
 - 当前有哪些 theme / prompt 真正可用

--- a/internal/assets/builtin/skills/md2wechat/SKILL.md
+++ b/internal/assets/builtin/skills/md2wechat/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: md2wechat
+description: Convert Markdown to WeChat Official Account HTML and drafts with discovery-first CLI commands.
+---
+
+# md2wechat CLI Skill
+
+This embedded skill is bundled with the installed binary. Prefer it over repository docs when operating an unknown md2wechat version.
+
+## Discovery First
+
+Use the CLI as the source of truth:
+
+```bash
+md2wechat version --json
+md2wechat capabilities --json
+md2wechat skills read md2wechat --json
+```
+
+Only run catalog discovery when it affects the next decision:
+
+```bash
+md2wechat themes list --json
+md2wechat layout list --json
+md2wechat providers list --json
+md2wechat prompts list --kind image --json
+md2wechat doctor --json
+```
+
+## Safe Workflow
+
+For article work, confirm before executing side effects:
+
+```bash
+md2wechat inspect article.md --json
+md2wechat preview article.md --json
+md2wechat convert article.md --preview
+```
+
+Add `--upload`, `--draft`, `--cover`, or `--cover-media-id` only when the user explicitly asks for upload or draft creation.
+
+## Decision Boundaries
+
+- `convert` defaults to API mode.
+- Advanced `:::module` layout blocks render only in API mode.
+- AI mode does not render advanced layout modules.
+- `preview` is local and does not upload images or create drafts.
+- `doctor --json` is local readiness only; it does not validate live auth.
+- `inspect --json` is the article-specific source of truth for `data.readiness.targets` and `data.readiness.blockers`.
+
+## Side Effects
+
+- Read-only discovery commands: `version`, `capabilities`, `skills`, `providers`, `themes`, `prompts`, `layout list/show`, `doctor`, `inspect`.
+- Local file writes: `preview`, `convert --output`, `write --output`, `humanize --output`, generated image commands.
+- Network or WeChat side effects: image generation providers, `upload_image`, `download_and_upload`, `convert --upload`, `convert --draft`, `create_draft`.
+
+## Failure Handling
+
+- Unknown theme or mode mismatch: run `md2wechat themes list --json` and choose a `selectable: true` theme whose `type` matches the mode.
+- Layout syntax errors: run `md2wechat layout validate --file <file> --json`, inspect the failing module with `layout show`, then validate again.
+- Draft blockers: read `inspect --json` readiness before assuming WeChat credentials or cover media are valid.
+- Configuration uncertainty: run `md2wechat doctor --json` and `md2wechat config show --format json`.

--- a/internal/assets/embed.go
+++ b/internal/assets/embed.go
@@ -2,13 +2,14 @@ package assets
 
 import (
 	"embed"
+	"fmt"
 	"io/fs"
 	"path"
 	"sort"
 	"strings"
 )
 
-//go:embed builtin/themes/*.yaml builtin/writers/*.yaml builtin/prompts/*/*.yaml builtin/layout/*/*.yaml
+//go:embed builtin/themes/*.yaml builtin/writers/*.yaml builtin/prompts/*/*.yaml builtin/layout/*/*.yaml builtin/skills/*/SKILL.md
 var builtinFS embed.FS
 
 func listYAMLNames(dir string) ([]string, error) {
@@ -84,4 +85,26 @@ func ListBuiltinLayouts(category string) ([]string, error) {
 
 func ReadBuiltinLayout(category, name string) ([]byte, error) {
 	return readYAMLFile(path.Join("builtin/layout", category), name)
+}
+
+func ListBuiltinSkills() ([]string, error) {
+	entries, err := fs.ReadDir(builtinFS, "builtin/skills")
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			names = append(names, entry.Name())
+		}
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func ReadBuiltinSkill(name string) ([]byte, error) {
+	if strings.TrimSpace(name) == "" || strings.ContainsAny(name, `/\`) || name == "." || name == ".." {
+		return nil, fmt.Errorf("invalid builtin skill name: %q", name)
+	}
+	return builtinFS.ReadFile(path.Join("builtin/skills", name, "SKILL.md"))
 }

--- a/skills/md2wechat/SKILL.md
+++ b/skills/md2wechat/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: md2wechat
-description: Convert Markdown to WeChat Official Account HTML. Use this whenever the user wants WeChat article formatting, article preview, WeChat draft upload, image generation for articles, cover or infographic generation, image-post creation, writer-style drafting, AI trace removal, or current discovery of supported providers, themes, prompts, and layout modules.
+description: Convert Markdown to WeChat Official Account HTML. Use this whenever the user wants WeChat article formatting, article preview, WeChat draft upload, image generation for articles, cover or infographic generation, image-post creation, writer-style drafting, AI trace removal, or current discovery of embedded skills, supported providers, themes, prompts, and layout modules.
 ---
 
 # md2wechat
@@ -16,6 +16,7 @@ Choose the command family before taking any publish or generation action:
 - Article cover or article infographic: prefer `generate_cover` or `generate_infographic` over raw `generate_image` when a bundled preset fits.
 - Writing in a creator style or removing AI traces: use `write` or `humanize`.
 - Provider, theme, prompt, or layout uncertainty: run discovery first. Do not guess from memory or repository files.
+- Skill/version uncertainty: read the embedded runtime skill from the installed binary before relying on this repository copy.
 
 Treat `convert --draft` and `create_image_post` as different publish targets, not interchangeable variants.
 
@@ -58,6 +59,12 @@ Run the smallest useful discovery set:
   md2wechat capabilities --json
   ```
 
+- Unknown installed skill protocol or possible doc drift:
+  ```bash
+  md2wechat skills list --json
+  md2wechat skills read md2wechat --json
+  ```
+
 For simple local actions such as `preview`, `humanize`, or a user-specified command with explicit flags, do not run unrelated provider, theme, prompt, or layout discovery.
 
 Inspect specific resources only when the task needs them:
@@ -69,7 +76,7 @@ md2wechat prompts show <name> --kind <kind> --json
 md2wechat layout show <name> --json
 ```
 
-Use CLI output as the source of truth for currently available modes, providers, themes, prompts, and layout modules.
+Use CLI output as the source of truth for currently available modes, providers, themes, prompts, layout modules, and embedded skill guidance.
 
 ## Configuration Boundaries
 


### PR DESCRIPTION

## Summary
- Add `md2wechat skills list/read` so agents can discover and read bundled runtime SOPs from the installed binary.
- Embed a compact `md2wechat` skill with side-effect metadata, risk level, read command, and sha256 content hash.
- Advertise `skills` in `capabilities` and sync README, Discovery, FAQ, and skill docs.

Closes #14

## Validation
- `gofmt -l .`
- `GOCACHE=/tmp/md2wechat-go-build go test ./cmd/md2wechat`
- `GOCACHE=/tmp/md2wechat-go-build go test ./...`
- `go vet ./...`
- `make quality-gates`
- `GOCACHE=/tmp/md2wechat-go-build go run ./cmd/md2wechat skills list --json`
- `GOCACHE=/tmp/md2wechat-go-build go run ./cmd/md2wechat skills read md2wechat --json`
