### PR TITLE
feat: support updating existing drafts

### DIFF
--- a/cmd/md2wechat/discovery.go
+++ b/cmd/md2wechat/discovery.go
@@ -323,7 +323,7 @@ func buildCapabilitiesData() (map[string]any, error) {
 	return map[string]any{
 		"commands": []string{
 			"convert", "inspect", "preview", "config", "write", "humanize", "upload_image",
-			"download_and_upload", "generate_image", "generate_cover", "generate_infographic", "create_draft",
+			"download_and_upload", "generate_image", "generate_cover", "generate_infographic", "create_draft", "update_draft",
 			"create_image_post", "test-draft", "providers", "themes",
 			"prompts", "layout", "brand", "doctor", "skills", "capabilities", "version",
 		},

--- a/cmd/md2wechat/discovery.go
+++ b/cmd/md2wechat/discovery.go
@@ -323,7 +323,7 @@ func buildCapabilitiesData() (map[string]any, error) {
 	return map[string]any{
 		"commands": []string{
 			"convert", "inspect", "preview", "config", "write", "humanize", "upload_image",
-			"download_and_upload", "generate_image", "generate_cover", "generate_infographic", "create_draft", "update_draft",
+			"download_and_upload", "generate_image", "generate_cover", "generate_infographic", "create_draft", "get_draft", "update_draft",
 			"create_image_post", "test-draft", "providers", "themes",
 			"prompts", "layout", "brand", "doctor", "skills", "capabilities", "version",
 		},

--- a/cmd/md2wechat/discovery.go
+++ b/cmd/md2wechat/discovery.go
@@ -323,7 +323,7 @@ func buildCapabilitiesData() (map[string]any, error) {
 	return map[string]any{
 		"commands": []string{
 			"convert", "inspect", "preview", "config", "write", "humanize", "upload_image",
-			"download_and_upload", "generate_image", "generate_cover", "generate_infographic", "create_draft", "get_draft", "update_draft",
+			"download_and_upload", "generate_image", "generate_cover", "generate_infographic", "create_draft", "get_draft", "update_draft", "preview_send",
 			"create_image_post", "test-draft", "providers", "themes",
 			"prompts", "layout", "brand", "doctor", "skills", "capabilities", "version",
 		},

--- a/cmd/md2wechat/discovery_test.go
+++ b/cmd/md2wechat/discovery_test.go
@@ -243,7 +243,7 @@ func TestBuildCapabilitiesDataKeepsConvertContractStableWithInspectAndPreview(t 
 	if !ok {
 		t.Fatalf("commands type = %T", data["commands"])
 	}
-	if !contains(commands, "inspect") || !contains(commands, "preview") || !contains(commands, "convert") {
+	if !contains(commands, "inspect") || !contains(commands, "preview") || !contains(commands, "convert") || !contains(commands, "preview_send") {
 		t.Fatalf("commands = %#v", commands)
 	}
 

--- a/cmd/md2wechat/main.go
+++ b/cmd/md2wechat/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/geekjourneyx/md2wechat-skill/internal/action"
 	"github.com/geekjourneyx/md2wechat-skill/internal/config"
 	"github.com/geekjourneyx/md2wechat-skill/internal/draft"
+	wechatservice "github.com/geekjourneyx/md2wechat-skill/internal/wechat"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 )
@@ -56,6 +57,7 @@ const (
 	codeImageGenerateFailed    = "IMAGE_GENERATE_FAILED"
 	codeDraftCreateFailed      = "DRAFT_CREATE_FAILED"
 	codeDraftGetFailed         = "DRAFT_GET_FAILED"
+	codeDraftPreviewFailed     = "DRAFT_PREVIEW_FAILED"
 	codeImagePostInvalid       = "IMAGE_POST_INVALID"
 	codeImagePostPreviewFailed = "IMAGE_POST_PREVIEW_FAILED"
 	codeImagePostCreateFailed  = "IMAGE_POST_CREATE_FAILED"
@@ -189,9 +191,11 @@ Examples:
   md2wechat upload_image ./photo.jpg
   md2wechat download_and_upload https://example.com/image.jpg
   md2wechat generate_image "A cute cat"
-  md2wechat create_draft draft.json
-  md2wechat get_draft <media_id> --output cloud-draft.json
-  md2wechat update_draft <media_id> draft.json --index 0`,
+	  md2wechat create_draft draft.json
+	  md2wechat get_draft <media_id> --output cloud-draft.json
+	  md2wechat update_draft <media_id> draft.json --index 0
+	  md2wechat preview_send <media_id> --openid OPENID
+	  md2wechat preview_send <media_id> --wxname WECHAT_ID`,
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		Version:       Version,
@@ -345,6 +349,44 @@ Examples:
 	}
 	updateDraftCmd.Flags().IntVar(&updateDraftIndex, "index", 0, "Article index inside the existing draft to update")
 	rootCmd.AddCommand(updateDraftCmd)
+
+	var previewSendOpenID string
+	var previewSendWxName string
+	var previewSendCmd = &cobra.Command{
+		Use:   "preview_send <media_id>",
+		Short: "Send an existing WeChat draft preview to one follower",
+		Args:  cobra.ExactArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return initConfig()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			mediaID := args[0]
+			if err := cfg.ValidateForWeChat(); err != nil {
+				return wrapCLIError(codeConfigInvalid, err, err.Error())
+			}
+			svc := wechatservice.NewService(cfg, log)
+			var result *wechatservice.PreviewDraftResult
+			var err error
+			switch {
+			case previewSendOpenID != "" && previewSendWxName != "":
+				return newCLIError(codeDraftPreviewFailed, "use exactly one of --openid or --wxname")
+			case previewSendOpenID != "":
+				result, err = svc.PreviewDraftToOpenID(mediaID, previewSendOpenID)
+			case previewSendWxName != "":
+				result, err = svc.PreviewDraftToWxName(mediaID, previewSendWxName)
+			default:
+				return newCLIError(codeDraftPreviewFailed, "one of --openid or --wxname is required")
+			}
+			if err != nil {
+				return wrapCLIError(codeDraftPreviewFailed, err, err.Error())
+			}
+			responseSuccess(result)
+			return nil
+		},
+	}
+	previewSendCmd.Flags().StringVar(&previewSendOpenID, "openid", "", "Follower openid to receive the preview")
+	previewSendCmd.Flags().StringVar(&previewSendWxName, "wxname", "", "WeChat ID to receive the preview")
+	rootCmd.AddCommand(previewSendCmd)
 
 	var versionCmd = &cobra.Command{
 		Use:   "version",

--- a/cmd/md2wechat/main.go
+++ b/cmd/md2wechat/main.go
@@ -60,6 +60,7 @@ const (
 	codeImagePostCreateFailed  = "IMAGE_POST_CREATE_FAILED"
 	codeImagePostPreviewReady  = "IMAGE_POST_PREVIEW_READY"
 	codeImagePostCreated       = "IMAGE_POST_CREATED"
+	codeDraftUpdateFailed      = "DRAFT_UPDATE_FAILED"
 	codeTestDraftReadFailed    = "TEST_DRAFT_READ_FAILED"
 	codeTestDraftCoverFailed   = "TEST_DRAFT_COVER_FAILED"
 	codeTestDraftCreateFailed  = "TEST_DRAFT_CREATE_FAILED"
@@ -187,7 +188,8 @@ Examples:
   md2wechat upload_image ./photo.jpg
   md2wechat download_and_upload https://example.com/image.jpg
   md2wechat generate_image "A cute cat"
-  md2wechat create_draft draft.json`,
+  md2wechat create_draft draft.json
+  md2wechat update_draft <media_id> draft.json --index 0`,
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		Version:       Version,
@@ -290,6 +292,32 @@ Examples:
 		},
 	}
 	rootCmd.AddCommand(createDraftCmd)
+
+	var updateDraftIndex int
+	var updateDraftCmd = &cobra.Command{
+		Use:   "update_draft <media_id> <json_file>",
+		Short: "Update an existing WeChat draft article from JSON file",
+		Args:  cobra.ExactArgs(2),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return initConfig()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			mediaID := args[0]
+			jsonFile := args[1]
+			if err := cfg.ValidateForWeChat(); err != nil {
+				return wrapCLIError(codeConfigInvalid, err, err.Error())
+			}
+			svc := draft.NewService(cfg, log)
+			result, err := svc.UpdateDraftFromFile(mediaID, updateDraftIndex, jsonFile)
+			if err != nil {
+				return wrapCLIError(codeDraftUpdateFailed, err, err.Error())
+			}
+			responseSuccess(result)
+			return nil
+		},
+	}
+	updateDraftCmd.Flags().IntVar(&updateDraftIndex, "index", 0, "Article index inside the existing draft to update")
+	rootCmd.AddCommand(updateDraftCmd)
 
 	var versionCmd = &cobra.Command{
 		Use:   "version",

--- a/cmd/md2wechat/main.go
+++ b/cmd/md2wechat/main.go
@@ -55,6 +55,7 @@ const (
 	codeImageUploadFailed      = "IMAGE_UPLOAD_FAILED"
 	codeImageGenerateFailed    = "IMAGE_GENERATE_FAILED"
 	codeDraftCreateFailed      = "DRAFT_CREATE_FAILED"
+	codeDraftGetFailed         = "DRAFT_GET_FAILED"
 	codeImagePostInvalid       = "IMAGE_POST_INVALID"
 	codeImagePostPreviewFailed = "IMAGE_POST_PREVIEW_FAILED"
 	codeImagePostCreateFailed  = "IMAGE_POST_CREATE_FAILED"
@@ -189,6 +190,7 @@ Examples:
   md2wechat download_and_upload https://example.com/image.jpg
   md2wechat generate_image "A cute cat"
   md2wechat create_draft draft.json
+  md2wechat get_draft <media_id> --output cloud-draft.json
   md2wechat update_draft <media_id> draft.json --index 0`,
 		SilenceErrors: true,
 		SilenceUsage:  true,
@@ -294,6 +296,31 @@ Examples:
 	rootCmd.AddCommand(createDraftCmd)
 
 	var updateDraftIndex int
+	var getDraftOutput string
+	var getDraftCmd = &cobra.Command{
+		Use:   "get_draft <media_id>",
+		Short: "Fetch an existing WeChat draft article as JSON",
+		Args:  cobra.ExactArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return initConfig()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			mediaID := args[0]
+			if err := cfg.ValidateForWeChat(); err != nil {
+				return wrapCLIError(codeConfigInvalid, err, err.Error())
+			}
+			svc := draft.NewService(cfg, log)
+			result, err := svc.GetDraft(mediaID, getDraftOutput)
+			if err != nil {
+				return wrapCLIError(codeDraftGetFailed, err, err.Error())
+			}
+			responseSuccess(result)
+			return nil
+		},
+	}
+	getDraftCmd.Flags().StringVarP(&getDraftOutput, "output", "o", "", "Write fetched draft JSON to this file")
+	rootCmd.AddCommand(getDraftCmd)
+
 	var updateDraftCmd = &cobra.Command{
 		Use:   "update_draft <media_id> <json_file>",
 		Short: "Update an existing WeChat draft article from JSON file",

--- a/internal/draft/service.go
+++ b/internal/draft/service.go
@@ -115,6 +115,44 @@ func (s *Service) CreateDraftFromFile(jsonFile string) (*DraftResult, error) {
 	}, nil
 }
 
+// UpdateDraftFromFile 从 JSON 文件更新已有草稿中的指定图文
+func (s *Service) UpdateDraftFromFile(mediaID string, index int, jsonFile string) (*DraftResult, error) {
+	s.log.Info("updating draft from file",
+		zap.String("media_id", mediaID),
+		zap.Int("index", index),
+		zap.String("file", jsonFile))
+
+	data, err := os.ReadFile(jsonFile)
+	if err != nil {
+		return nil, fmt.Errorf("read file: %w", err)
+	}
+
+	var req DraftRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return nil, fmt.Errorf("parse json: %w", err)
+	}
+
+	article, err := articleForUpdate(req, index)
+	if err != nil {
+		return nil, err
+	}
+
+	sdkArticle, err := buildSDKArticle(article)
+	if err != nil {
+		return nil, fmt.Errorf("article %d: %w", index, err)
+	}
+
+	result, err := s.ws.UpdateDraft(mediaID, index, sdkArticle)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DraftResult{
+		MediaID:  result.MediaID,
+		DraftURL: result.DraftURL,
+	}, nil
+}
+
 // CreateDraft 创建草稿
 func (s *Service) CreateDraft(articles []Article) (*DraftResult, error) {
 	// 转换为 SDK 格式
@@ -145,6 +183,16 @@ func buildSDKArticles(articles []Article) ([]*draft.Article, error) {
 		sdkArticles = append(sdkArticles, sdkArticle)
 	}
 	return sdkArticles, nil
+}
+
+func articleForUpdate(req DraftRequest, index int) (Article, error) {
+	if len(req.Articles) == 0 {
+		return Article{}, fmt.Errorf("no articles in request")
+	}
+	if index < 0 || index >= len(req.Articles) {
+		return Article{}, fmt.Errorf("article index %d out of range", index)
+	}
+	return req.Articles[index], nil
 }
 
 func buildSDKArticle(article Article) (*draft.Article, error) {

--- a/internal/draft/service.go
+++ b/internal/draft/service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	stdhtml "html"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -76,6 +77,14 @@ type DraftResult struct {
 	DraftURL string `json:"draft_url,omitempty"`
 }
 
+// DraftPullResult 草稿读取结果
+type DraftPullResult struct {
+	MediaID  string       `json:"media_id"`
+	Articles []Article    `json:"articles"`
+	Output   string       `json:"output,omitempty"`
+	Draft    DraftRequest `json:"draft"`
+}
+
 // CreateDraftFromFile 从 JSON 文件创建草稿
 func (s *Service) CreateDraftFromFile(jsonFile string) (*DraftResult, error) {
 	s.log.Info("creating draft from file", zap.String("file", jsonFile))
@@ -112,6 +121,39 @@ func (s *Service) CreateDraftFromFile(jsonFile string) (*DraftResult, error) {
 	return &DraftResult{
 		MediaID:  result.MediaID,
 		DraftURL: result.DraftURL,
+	}, nil
+}
+
+// GetDraft 读取云端已有草稿，并可保存为 create/update 兼容 JSON
+func (s *Service) GetDraft(mediaID string, outputFile string) (*DraftPullResult, error) {
+	s.log.Info("getting draft", zap.String("media_id", mediaID))
+
+	if strings.TrimSpace(mediaID) == "" {
+		return nil, fmt.Errorf("media_id is required")
+	}
+
+	sdkArticles, err := s.ws.GetDraft(mediaID)
+	if err != nil {
+		return nil, err
+	}
+
+	articles := make([]Article, 0, len(sdkArticles))
+	for _, sdkArticle := range sdkArticles {
+		articles = append(articles, articleFromSDKArticle(sdkArticle))
+	}
+	req := DraftRequest{Articles: articles}
+
+	if outputFile != "" {
+		if err := writeDraftRequest(outputFile, req); err != nil {
+			return nil, err
+		}
+	}
+
+	return &DraftPullResult{
+		MediaID:  mediaID,
+		Articles: articles,
+		Output:   outputFile,
+		Draft:    req,
 	}, nil
 }
 
@@ -195,6 +237,23 @@ func articleForUpdate(req DraftRequest, index int) (Article, error) {
 	return req.Articles[index], nil
 }
 
+func articleFromSDKArticle(sdkArticle *draft.Article) Article {
+	if sdkArticle == nil {
+		return Article{}
+	}
+	return Article{
+		Title:              sdkArticle.Title,
+		Author:             sdkArticle.Author,
+		Digest:             sdkArticle.Digest,
+		Content:            sdkArticle.Content,
+		ContentSourceURL:   sdkArticle.ContentSourceURL,
+		ThumbMediaID:       sdkArticle.ThumbMediaID,
+		ShowCoverPic:       int(sdkArticle.ShowCoverPic),
+		NeedOpenComment:    int(sdkArticle.NeedOpenComment),
+		OnlyFansCanComment: int(sdkArticle.OnlyFansCanComment),
+	}
+}
+
 func buildSDKArticle(article Article) (*draft.Article, error) {
 	if article.Title == "" {
 		return nil, fmt.Errorf("title is required")
@@ -204,10 +263,12 @@ func buildSDKArticle(article Article) (*draft.Article, error) {
 	}
 
 	sdkArticle := &draft.Article{
-		Title:   article.Title,
-		Content: article.Content,
-		Digest:  article.Digest,
-		Author:  article.Author,
+		Title:              article.Title,
+		Content:            article.Content,
+		Digest:             article.Digest,
+		Author:             article.Author,
+		NeedOpenComment:    uint(article.NeedOpenComment),
+		OnlyFansCanComment: uint(article.OnlyFansCanComment),
 	}
 
 	if article.ThumbMediaID != "" {
@@ -220,6 +281,22 @@ func buildSDKArticle(article Article) (*draft.Article, error) {
 	}
 
 	return sdkArticle, nil
+}
+
+func writeDraftRequest(outputFile string, req DraftRequest) error {
+	data, err := json.MarshalIndent(req, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal draft: %w", err)
+	}
+	if dir := filepath.Dir(outputFile); dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("create output directory: %w", err)
+		}
+	}
+	if err := os.WriteFile(outputFile, append(data, '\n'), 0600); err != nil {
+		return fmt.Errorf("write output: %w", err)
+	}
+	return nil
 }
 
 // GenerateDigestFromContent 从内容生成摘要

--- a/internal/draft/service_test.go
+++ b/internal/draft/service_test.go
@@ -71,6 +71,35 @@ func TestCreateDraftFromFileValidationErrors(t *testing.T) {
 	}
 }
 
+func TestArticleForUpdateSelectsRequestedIndex(t *testing.T) {
+	req := DraftRequest{
+		Articles: []Article{
+			{Title: "First", Content: "one"},
+			{Title: "Second", Content: "two"},
+		},
+	}
+
+	got, err := articleForUpdate(req, 1)
+	if err != nil {
+		t.Fatalf("articleForUpdate() error = %v", err)
+	}
+	if got.Title != "Second" || got.Content != "two" {
+		t.Fatalf("articleForUpdate() = %#v", got)
+	}
+}
+
+func TestArticleForUpdateValidationErrors(t *testing.T) {
+	if _, err := articleForUpdate(DraftRequest{}, 0); err == nil {
+		t.Fatal("expected no articles error")
+	}
+	if _, err := articleForUpdate(DraftRequest{Articles: []Article{{Title: "Only", Content: "one"}}}, 1); err == nil {
+		t.Fatal("expected index out of range error")
+	}
+	if _, err := articleForUpdate(DraftRequest{Articles: []Article{{Title: "Only", Content: "one"}}}, -1); err == nil {
+		t.Fatal("expected negative index error")
+	}
+}
+
 func TestBuildSDKArticleConvertsOptionalFields(t *testing.T) {
 	got, err := buildSDKArticle(Article{
 		Title:            "Title",

--- a/internal/draft/service_test.go
+++ b/internal/draft/service_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	sdkdraft "github.com/silenceper/wechat/v2/officialaccount/draft"
 	"go.uber.org/zap"
 )
 
@@ -119,6 +120,72 @@ func TestBuildSDKArticleConvertsOptionalFields(t *testing.T) {
 	}
 	if got.ThumbMediaID != "thumb-id" || got.ShowCoverPic != 1 || got.ContentSourceURL != "https://example.com/source" {
 		t.Fatalf("buildSDKArticle() optional fields = %#v", got)
+	}
+}
+
+func TestBuildSDKArticleConvertsCommentFields(t *testing.T) {
+	got, err := buildSDKArticle(Article{
+		Title:              "Title",
+		Content:            "<p>body</p>",
+		NeedOpenComment:    1,
+		OnlyFansCanComment: 1,
+	})
+	if err != nil {
+		t.Fatalf("buildSDKArticle() error = %v", err)
+	}
+
+	if got.NeedOpenComment != 1 || got.OnlyFansCanComment != 1 {
+		t.Fatalf("comment fields = %#v", got)
+	}
+}
+
+func TestArticleFromSDKArticlePreservesDraftFields(t *testing.T) {
+	got := articleFromSDKArticle(&sdkdraft.Article{
+		Title:              "Title",
+		Author:             "Author",
+		Digest:             "Digest",
+		Content:            "<p>body</p>",
+		ContentSourceURL:   "https://example.com/source",
+		ThumbMediaID:       "thumb",
+		ShowCoverPic:       1,
+		NeedOpenComment:    1,
+		OnlyFansCanComment: 1,
+	})
+
+	if got.Title != "Title" || got.Author != "Author" || got.Digest != "Digest" || got.Content != "<p>body</p>" {
+		t.Fatalf("articleFromSDKArticle() = %#v", got)
+	}
+	if got.ContentSourceURL != "https://example.com/source" || got.ThumbMediaID != "thumb" || got.ShowCoverPic != 1 {
+		t.Fatalf("optional fields = %#v", got)
+	}
+	if got.NeedOpenComment != 1 || got.OnlyFansCanComment != 1 {
+		t.Fatalf("comment fields = %#v", got)
+	}
+}
+
+func TestWriteDraftRequestCreatesJSONFile(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "nested", "draft.json")
+	req := DraftRequest{
+		Articles: []Article{{
+			Title:   "Title",
+			Content: "<p>body</p>",
+		}},
+	}
+
+	if err := writeDraftRequest(out, req); err != nil {
+		t.Fatalf("writeDraftRequest() error = %v", err)
+	}
+
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	var got DraftRequest
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal output: %v\n%s", err, data)
+	}
+	if len(got.Articles) != 1 || got.Articles[0].Title != "Title" {
+		t.Fatalf("output draft = %#v", got)
 	}
 }
 

--- a/internal/wechat/service.go
+++ b/internal/wechat/service.go
@@ -117,6 +117,19 @@ type CreateDraftResult struct {
 	DraftURL string `json:"draft_url,omitempty"`
 }
 
+// UpdateDraftRequest 微信草稿更新请求
+type UpdateDraftRequest struct {
+	MediaID  string         `json:"media_id"`
+	Index    int            `json:"index"`
+	Articles *draft.Article `json:"articles"`
+}
+
+// UpdateDraftResponse 微信草稿更新响应
+type UpdateDraftResponse struct {
+	ErrCode int    `json:"errcode"`
+	ErrMsg  string `json:"errmsg"`
+}
+
 // CreateDraft 创建草稿
 func (s *Service) CreateDraft(articles []*draft.Article) (*CreateDraftResult, error) {
 	startTime := time.Now()
@@ -133,6 +146,68 @@ func (s *Service) CreateDraft(articles []*draft.Article) (*CreateDraftResult, er
 	duration := time.Since(startTime)
 	s.log.Info("draft created",
 		zap.String("media_id", maskMediaID(mediaID)),
+		zap.Duration("duration", duration))
+
+	return &CreateDraftResult{
+		MediaID: mediaID,
+	}, nil
+}
+
+// UpdateDraft 更新已有草稿中的单篇图文
+func (s *Service) UpdateDraft(mediaID string, index int, article *draft.Article) (*CreateDraftResult, error) {
+	startTime := time.Now()
+
+	oa := s.getOfficialAccount()
+	accessToken, err := oa.GetAccessToken()
+	if err != nil {
+		return nil, fmt.Errorf("get access token: %w", err)
+	}
+
+	req := UpdateDraftRequest{
+		MediaID:  mediaID,
+		Index:    index,
+		Articles: article,
+	}
+	reqBody, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	apiURL := fmt.Sprintf("https://api.weixin.qq.com/cgi-bin/draft/update?access_token=%s", accessToken)
+	httpReq, err := http.NewRequest(http.MethodPost, apiURL, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := s.getHTTPClient().Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("call wechat api: %w", err)
+	}
+	defer func() {
+		_ = httpResp.Body.Close()
+	}()
+
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	var resp UpdateDraftResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	if resp.ErrCode != 0 {
+		s.log.Error("update draft failed",
+			zap.Int("errcode", resp.ErrCode),
+			zap.String("errmsg", resp.ErrMsg))
+		return nil, fmt.Errorf("%s", ExplainDraftAPIError(resp.ErrCode, resp.ErrMsg))
+	}
+
+	duration := time.Since(startTime)
+	s.log.Info("draft updated",
+		zap.String("media_id", maskMediaID(mediaID)),
+		zap.Int("index", index),
 		zap.Duration("duration", duration))
 
 	return &CreateDraftResult{

--- a/internal/wechat/service.go
+++ b/internal/wechat/service.go
@@ -117,6 +117,25 @@ type CreateDraftResult struct {
 	DraftURL string `json:"draft_url,omitempty"`
 }
 
+// PreviewDraftResult contains WeChat's preview-send response.
+type PreviewDraftResult struct {
+	MediaID    string `json:"media_id"`
+	OpenID     string `json:"openid,omitempty"`
+	WxName     string `json:"wxname,omitempty"`
+	MsgID      int64  `json:"msg_id"`
+	MsgDataID  int64  `json:"msg_data_id"`
+	MsgStatus  string `json:"msg_status,omitempty"`
+	PreviewURL string `json:"preview_url,omitempty"`
+}
+
+type previewDraftResponse struct {
+	ErrCode   int    `json:"errcode"`
+	ErrMsg    string `json:"errmsg"`
+	MsgID     int64  `json:"msg_id"`
+	MsgDataID int64  `json:"msg_data_id"`
+	MsgStatus string `json:"msg_status"`
+}
+
 // UpdateDraftRequest 微信草稿更新请求
 type UpdateDraftRequest struct {
 	MediaID  string         `json:"media_id"`
@@ -174,6 +193,95 @@ func (s *Service) GetDraft(mediaID string) ([]*draft.Article, error) {
 		zap.Duration("duration", duration))
 
 	return articles, nil
+}
+
+// PreviewDraftToOpenID sends an mpnews draft preview to one follower by openid.
+func (s *Service) PreviewDraftToOpenID(mediaID string, openID string) (*PreviewDraftResult, error) {
+	return s.previewDraft(mediaID, openID, "")
+}
+
+// PreviewDraftToWxName sends an mpnews draft preview to one follower by WeChat ID.
+func (s *Service) PreviewDraftToWxName(mediaID string, wxName string) (*PreviewDraftResult, error) {
+	return s.previewDraft(mediaID, "", wxName)
+}
+
+func (s *Service) previewDraft(mediaID string, openID string, wxName string) (*PreviewDraftResult, error) {
+	mediaID = strings.TrimSpace(mediaID)
+	openID = strings.TrimSpace(openID)
+	wxName = strings.TrimSpace(wxName)
+	if mediaID == "" {
+		return nil, errors.New("media_id is required")
+	}
+	if (openID == "") == (wxName == "") {
+		return nil, errors.New("exactly one of openid or wxname is required")
+	}
+	startTime := time.Now()
+	oa := s.getOfficialAccount()
+	accessToken, err := oa.GetAccessToken()
+	if err != nil {
+		return nil, fmt.Errorf("get access token: %w", err)
+	}
+
+	req := map[string]any{
+		"mpnews": map[string]any{
+			"media_id": mediaID,
+		},
+		"msgtype": "mpnews",
+	}
+	if openID != "" {
+		req["touser"] = openID
+	} else {
+		req["towxname"] = wxName
+	}
+	reqBody, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	apiURL := fmt.Sprintf("https://api.weixin.qq.com/cgi-bin/message/mass/preview?access_token=%s", accessToken)
+	httpReq, err := http.NewRequest(http.MethodPost, apiURL, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := s.getHTTPClient().Do(httpReq)
+	if err != nil {
+		s.log.Error("preview draft failed",
+			zap.String("media_id", maskMediaID(mediaID)),
+			zap.Error(err))
+		return nil, fmt.Errorf("call wechat api: %w", err)
+	}
+	defer func() {
+		_ = httpResp.Body.Close()
+	}()
+
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	var resp previewDraftResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	if resp.ErrCode != 0 {
+		return nil, ExplainDraftError(fmt.Errorf("wechat api error: %d - %s", resp.ErrCode, resp.ErrMsg))
+	}
+
+	duration := time.Since(startTime)
+	s.log.Info("draft preview sent",
+		zap.String("media_id", maskMediaID(mediaID)),
+		zap.Duration("duration", duration))
+
+	return &PreviewDraftResult{
+		MediaID:   mediaID,
+		OpenID:    openID,
+		WxName:    wxName,
+		MsgID:     resp.MsgID,
+		MsgDataID: resp.MsgDataID,
+		MsgStatus: resp.MsgStatus,
+	}, nil
 }
 
 // UpdateDraft 更新已有草稿中的单篇图文

--- a/internal/wechat/service.go
+++ b/internal/wechat/service.go
@@ -153,6 +153,29 @@ func (s *Service) CreateDraft(articles []*draft.Article) (*CreateDraftResult, er
 	}, nil
 }
 
+// GetDraft 获取已有草稿图文列表
+func (s *Service) GetDraft(mediaID string) ([]*draft.Article, error) {
+	startTime := time.Now()
+	oa := s.getOfficialAccount()
+	dm := oa.GetDraft()
+
+	articles, err := dm.GetDraft(mediaID)
+	if err != nil {
+		s.log.Error("get draft failed",
+			zap.String("media_id", maskMediaID(mediaID)),
+			zap.Error(err))
+		return nil, fmt.Errorf("get draft: %w", ExplainDraftError(err))
+	}
+
+	duration := time.Since(startTime)
+	s.log.Info("draft fetched",
+		zap.String("media_id", maskMediaID(mediaID)),
+		zap.Int("articles", len(articles)),
+		zap.Duration("duration", duration))
+
+	return articles, nil
+}
+
 // UpdateDraft 更新已有草稿中的单篇图文
 func (s *Service) UpdateDraft(mediaID string, index int, article *draft.Article) (*CreateDraftResult, error) {
 	startTime := time.Now()

--- a/internal/wechat/service_test.go
+++ b/internal/wechat/service_test.go
@@ -295,6 +295,85 @@ func TestCreateDraftUsesAccessTokenAndReturnsMediaIDOnly(t *testing.T) {
 	}
 }
 
+func TestUpdateDraftPostsJSONAndReturnsExistingMediaID(t *testing.T) {
+	oldClient := util.DefaultHTTPClient
+	var draftRequestBody []byte
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch {
+			case strings.Contains(req.URL.String(), "/cgi-bin/token"):
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"access_token":"token-123","expires_in":7200}`)),
+					Header:     make(http.Header),
+					Request:    req,
+				}, nil
+			case strings.Contains(req.URL.String(), "/cgi-bin/draft/update"):
+				if req.Method != http.MethodPost {
+					t.Fatalf("request method = %s, want POST", req.Method)
+				}
+				if got := req.Header.Get("Content-Type"); got != "application/json" {
+					t.Fatalf("content type = %q, want application/json", got)
+				}
+				if !strings.Contains(req.URL.String(), "access_token=token-123") {
+					t.Fatalf("request url missing token: %s", req.URL.String())
+				}
+				body, err := io.ReadAll(req.Body)
+				if err != nil {
+					return nil, err
+				}
+				draftRequestBody = append([]byte(nil), body...)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"errcode":0,"errmsg":"ok"}`)),
+					Header:     make(http.Header),
+					Request:    req,
+				}, nil
+			default:
+				t.Fatalf("unexpected request url: %s", req.URL.String())
+				return nil, nil
+			}
+		}),
+	}
+	t.Cleanup(func() {
+		util.DefaultHTTPClient = oldClient
+	})
+	util.DefaultHTTPClient = httpClient
+
+	svc := &Service{
+		cfg: &config.Config{
+			WechatAppID:  "appid",
+			WechatSecret: "secret",
+		},
+		log:        zap.NewNop(),
+		httpClient: httpClient,
+	}
+
+	result, err := svc.UpdateDraft("draft-media-123", 0, &draft.Article{
+		Title:        "Updated title",
+		Content:      "<p>updated</p>",
+		Digest:       "Updated digest",
+		ThumbMediaID: "thumb-123",
+	})
+	if err != nil {
+		t.Fatalf("UpdateDraft() error = %v", err)
+	}
+	if result.MediaID != "draft-media-123" {
+		t.Fatalf("media id = %q, want existing media id", result.MediaID)
+	}
+
+	var req UpdateDraftRequest
+	if err := json.Unmarshal(draftRequestBody, &req); err != nil {
+		t.Fatalf("unmarshal request body: %v", err)
+	}
+	if req.MediaID != "draft-media-123" || req.Index != 0 {
+		t.Fatalf("request identity = %#v", req)
+	}
+	if req.Articles.Title != "Updated title" || req.Articles.Content != "<p>updated</p>" || req.Articles.ThumbMediaID != "thumb-123" {
+		t.Fatalf("request article = %#v", req.Articles)
+	}
+}
+
 func TestCreateNewspicDraftPostsJSONAndReturnsMediaID(t *testing.T) {
 	oldClient := util.DefaultHTTPClient
 	var draftRequestBody []byte

--- a/internal/wechat/service_test.go
+++ b/internal/wechat/service_test.go
@@ -295,6 +295,137 @@ func TestCreateDraftUsesAccessTokenAndReturnsMediaIDOnly(t *testing.T) {
 	}
 }
 
+func TestPreviewDraftToOpenIDUsesMassPreviewEndpoint(t *testing.T) {
+	oldClient := util.DefaultHTTPClient
+	var previewRequestBody []byte
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch {
+			case strings.Contains(req.URL.String(), "/cgi-bin/token"):
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"access_token":"token-123","expires_in":7200}`)),
+					Header:     make(http.Header),
+					Request:    req,
+				}, nil
+			case strings.Contains(req.URL.String(), "/cgi-bin/message/mass/preview"):
+				if req.URL.Query().Get("access_token") != "token-123" {
+					t.Fatalf("access token = %q", req.URL.Query().Get("access_token"))
+				}
+				body, err := io.ReadAll(req.Body)
+				if err != nil {
+					t.Fatalf("read request body: %v", err)
+				}
+				previewRequestBody = body
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"errcode":0,"errmsg":"preview ok","msg_id":123,"msg_data_id":456,"msg_status":"SEND_SUCCESS"}`)),
+					Header:     make(http.Header),
+					Request:    req,
+				}, nil
+			default:
+				t.Fatalf("unexpected request url: %s", req.URL.String())
+				return nil, nil
+			}
+		}),
+	}
+	t.Cleanup(func() {
+		util.DefaultHTTPClient = oldClient
+	})
+	util.DefaultHTTPClient = httpClient
+
+	svc := &Service{
+		cfg: &config.Config{
+			WechatAppID:  "appid",
+			WechatSecret: "secret",
+		},
+		log:        zap.NewNop(),
+		httpClient: httpClient,
+	}
+
+	result, err := svc.PreviewDraftToOpenID("draft-media-123", "openid-abc")
+	if err != nil {
+		t.Fatalf("PreviewDraftToOpenID() error = %v", err)
+	}
+	if result.MsgID != 123 || result.MsgDataID != 456 || result.MsgStatus != "SEND_SUCCESS" {
+		t.Fatalf("result = %#v", result)
+	}
+
+	var req map[string]any
+	if err := json.Unmarshal(previewRequestBody, &req); err != nil {
+		t.Fatalf("unmarshal request body: %v", err)
+	}
+	if req["touser"] != "openid-abc" || req["msgtype"] != "mpnews" {
+		t.Fatalf("request identity fields = %#v", req)
+	}
+	mpnews, ok := req["mpnews"].(map[string]any)
+	if !ok || mpnews["media_id"] != "draft-media-123" {
+		t.Fatalf("mpnews payload = %#v", req["mpnews"])
+	}
+}
+
+func TestPreviewDraftToWxNameUsesMassPreviewEndpoint(t *testing.T) {
+	oldClient := util.DefaultHTTPClient
+	var previewRequestBody []byte
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch {
+			case strings.Contains(req.URL.String(), "/cgi-bin/token"):
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"access_token":"token-123","expires_in":7200}`)),
+					Header:     make(http.Header),
+					Request:    req,
+				}, nil
+			case strings.Contains(req.URL.String(), "/cgi-bin/message/mass/preview"):
+				body, err := io.ReadAll(req.Body)
+				if err != nil {
+					t.Fatalf("read request body: %v", err)
+				}
+				previewRequestBody = body
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"errcode":0,"errmsg":"preview ok","msg_id":321,"msg_data_id":654}`)),
+					Header:     make(http.Header),
+					Request:    req,
+				}, nil
+			default:
+				t.Fatalf("unexpected request url: %s", req.URL.String())
+				return nil, nil
+			}
+		}),
+	}
+	t.Cleanup(func() {
+		util.DefaultHTTPClient = oldClient
+	})
+	util.DefaultHTTPClient = httpClient
+
+	svc := &Service{
+		cfg: &config.Config{
+			WechatAppID:  "appid",
+			WechatSecret: "secret",
+		},
+		log:        zap.NewNop(),
+		httpClient: httpClient,
+	}
+
+	result, err := svc.PreviewDraftToWxName("draft-media-123", "wechat-id")
+	if err != nil {
+		t.Fatalf("PreviewDraftToWxName() error = %v", err)
+	}
+	if result.MsgID != 321 || result.MsgDataID != 654 || result.WxName != "wechat-id" {
+		t.Fatalf("result = %#v", result)
+	}
+
+	var req map[string]any
+	if err := json.Unmarshal(previewRequestBody, &req); err != nil {
+		t.Fatalf("unmarshal request body: %v", err)
+	}
+	if req["towxname"] != "wechat-id" || req["touser"] != nil {
+		t.Fatalf("request identity fields = %#v", req)
+	}
+}
+
 func TestUpdateDraftPostsJSONAndReturnsExistingMediaID(t *testing.T) {
 	oldClient := util.DefaultHTTPClient
 	var draftRequestBody []byte

--- a/platforms/openclaw/md2wechat/SKILL.md
+++ b/platforms/openclaw/md2wechat/SKILL.md
@@ -83,6 +83,7 @@ Use CLI output as the source of truth for currently available modes, providers, 
 - `convert` defaults to API mode unless the user explicitly asks for `--mode ai`.
 - API conversion requires md2wechat API credentials.
 - WeChat draft creation requires WeChat credentials.
+- If the user provides an existing draft `media_id`, prefer `md2wechat update_draft <media_id> <json_file> --index <n>` over creating a new draft. Use `create_draft` only when no existing draft should be preserved or update is unavailable.
 - Image generation may require image-provider credentials.
 - `doctor --json` is local-only: it checks local readiness and does not perform live authentication, upload images, or create drafts.
 - Use `config show --format json` when the user asks what configuration is currently effective.
@@ -178,6 +179,12 @@ Before draft creation:
 - Draft creation requires a cover via `--cover` or `--cover-media-id`.
 - Do not assume a WeChat URL or `mmbiz.qpic.cn` URL can be reused as `thumb_media_id`.
 - If draft creation returns `45004`, check digest, summary, and description before assuming the body is too long.
+
+Before updating an existing draft:
+
+- Confirm the target draft `media_id` and article `--index` (default `0` for single-article drafts).
+- Reuse the same JSON article format as `create_draft`; `update_draft` updates only `articles[index]`.
+- If the update fails because the CLI lacks `update_draft` or the API rejects the media ID, report the blocker before creating a replacement draft.
 
 Markdown images are uploaded or replaced only during `--upload` or `--draft`, not during plain conversion or preview.
 

--- a/skills/md2wechat/SKILL.md
+++ b/skills/md2wechat/SKILL.md
@@ -83,6 +83,7 @@ Use CLI output as the source of truth for currently available modes, providers, 
 - WeChat draft creation requires WeChat credentials.
 - If the user provides an existing draft `media_id`, prefer `md2wechat update_draft <media_id> <json_file> --index <n>` over creating a new draft. Use `create_draft` only when no existing draft should be preserved or update is unavailable.
 - If a user may edit the draft manually, pull the cloud draft first with `md2wechat get_draft <media_id> --output <cloud-json>` and base edits on that fetched JSON. Do not update from an older local JSON artifact when the cloud draft may have changed.
+- To send an existing draft preview without changing it, use `md2wechat preview_send <media_id> --openid <openid>` or `--wxname <wechat_id>`. If WeChat returns `48001`, report that the account lacks mass preview API permission.
 - Image generation may require image-provider credentials.
 - `doctor --json` is local-only: it checks local readiness and does not perform live authentication, upload images, or create drafts.
 - Use `config show --format json` when the user asks what configuration is currently effective.
@@ -192,6 +193,12 @@ Before updating an existing draft:
 - Reuse the same JSON article format as `create_draft`; `update_draft` updates only `articles[index]`.
 - If the CLI lacks `get_draft`, report that cloud edits cannot be safely preserved before updating.
 - If the update fails because the CLI lacks `update_draft` or the API rejects the media ID, report the blocker before creating a replacement draft.
+
+Before sending a draft preview:
+
+- Use `md2wechat preview_send <media_id> --openid <openid>` when an openid is known, or `--wxname <wechat_id>` when the user provides a WeChat ID.
+- Preview sending does not modify the draft, but it still calls a live WeChat API and sends the article preview to the target user.
+- If the API returns `48001 api unauthorized`, do not retry with the same credentials; the account lacks permission for the mass preview endpoint.
 
 Markdown images are uploaded or replaced only during `--upload` or `--draft`, not during plain conversion or preview.
 

--- a/skills/md2wechat/SKILL.md
+++ b/skills/md2wechat/SKILL.md
@@ -81,6 +81,7 @@ Use CLI output as the source of truth for currently available modes, providers, 
 - `convert` defaults to API mode unless the user explicitly asks for `--mode ai`.
 - API conversion requires md2wechat API credentials.
 - WeChat draft creation requires WeChat credentials.
+- If the user provides an existing draft `media_id`, prefer `md2wechat update_draft <media_id> <json_file> --index <n>` over creating a new draft. Use `create_draft` only when no existing draft should be preserved or update is unavailable.
 - Image generation may require image-provider credentials.
 - `doctor --json` is local-only: it checks local readiness and does not perform live authentication, upload images, or create drafts.
 - Use `config show --format json` when the user asks what configuration is currently effective.
@@ -176,6 +177,12 @@ Before draft creation:
 - Draft creation requires a cover via `--cover` or `--cover-media-id`.
 - Do not assume a WeChat URL or `mmbiz.qpic.cn` URL can be reused as `thumb_media_id`.
 - If draft creation returns `45004`, check digest, summary, and description before assuming the body is too long.
+
+Before updating an existing draft:
+
+- Confirm the target draft `media_id` and article `--index` (default `0` for single-article drafts).
+- Reuse the same JSON article format as `create_draft`; `update_draft` updates only `articles[index]`.
+- If the update fails because the CLI lacks `update_draft` or the API rejects the media ID, report the blocker before creating a replacement draft.
 
 Markdown images are uploaded or replaced only during `--upload` or `--draft`, not during plain conversion or preview.
 

--- a/skills/md2wechat/SKILL.md
+++ b/skills/md2wechat/SKILL.md
@@ -112,6 +112,8 @@ When the user asks to format an article and has not chosen a theme or modules:
 
 Saving generated Markdown next to the source file requires explicit user confirmation and must not overwrite the source.
 
+For final inline HTML that will be pasted into or uploaded to WeChat drafts, avoid native `<ul>` / `<li>` for visible article lists unless that exact rendering has been verified in the WeChat editor. The editor/client may add default list spacing on top of inline styles. Render compact lists as separate `<p>` lines with an inline bullet such as `&bull;` and explicit `margin` / `line-height`.
+
 ## Theme Selection
 
 - Read `type` and `selectable` from `themes list --json`.

--- a/skills/md2wechat/SKILL.md
+++ b/skills/md2wechat/SKILL.md
@@ -82,6 +82,7 @@ Use CLI output as the source of truth for currently available modes, providers, 
 - API conversion requires md2wechat API credentials.
 - WeChat draft creation requires WeChat credentials.
 - If the user provides an existing draft `media_id`, prefer `md2wechat update_draft <media_id> <json_file> --index <n>` over creating a new draft. Use `create_draft` only when no existing draft should be preserved or update is unavailable.
+- If a user may edit the draft manually, pull the cloud draft first with `md2wechat get_draft <media_id> --output <cloud-json>` and base edits on that fetched JSON. Do not update from an older local JSON artifact when the cloud draft may have changed.
 - Image generation may require image-provider credentials.
 - `doctor --json` is local-only: it checks local readiness and does not perform live authentication, upload images, or create drafts.
 - Use `config show --format json` when the user asks what configuration is currently effective.
@@ -183,7 +184,13 @@ Before draft creation:
 Before updating an existing draft:
 
 - Confirm the target draft `media_id` and article `--index` (default `0` for single-article drafts).
+- Pull the latest cloud draft first:
+  ```bash
+  md2wechat get_draft <media_id> --output /tmp/md2wechat-format/<run-id>/cloud-draft.json --json
+  ```
+  Use the fetched JSON as the base for edits, so manual changes made in the WeChat editor are preserved.
 - Reuse the same JSON article format as `create_draft`; `update_draft` updates only `articles[index]`.
+- If the CLI lacks `get_draft`, report that cloud edits cannot be safely preserved before updating.
 - If the update fails because the CLI lacks `update_draft` or the API rejects the media ID, report the blocker before creating a replacement draft.
 
 Markdown images are uploaded or replaced only during `--upload` or `--draft`, not during plain conversion or preview.

--- a/skills/md2wechat/templates/README.md
+++ b/skills/md2wechat/templates/README.md
@@ -1,0 +1,40 @@
+# Template Library
+
+This directory stores reusable fallback templates for `md2wechat` article formatting.
+
+## Current Templates
+
+- `event-blue-card-inline.html.tmpl`
+  - Origin: derived from a real WeChat event article publish flow
+  - Use when: event or announcement content needs calm blue cards, clear sectioning, and fully inline HTML compatible with WeChat
+  - Notes: supports overview blocks, info sections, body sections, CTA blocks, and inline images
+
+## Usage Rules
+
+- Start from the closest existing template before creating a new one.
+- Prefer placeholder tokens over hardcoded live copy.
+- Keep CSS inline and tag usage WeChat-safe.
+- Avoid native `<ul>` / `<li>` for visible article lists. WeChat's editor/client can add default list spacing on top of inline styles; use separate `<p>` lines with `&bull;` and explicit margins for compact lists.
+- If an AI prompt adds style guidance, apply only the deltas that matter instead of rewriting the template from scratch.
+- Add templates with descriptive names tied to content goal and visual system.
+
+## Placeholder Conventions
+
+Use double-underscore tokens such as:
+
+- `__EYEBROW__`
+- `__TITLE__`
+- `__SUMMARY__`
+- `__OVERVIEW_LABEL__`
+- `__OVERVIEW_HTML__`
+- `__INFO_HEADING__`
+- `__INFO_LIST_HTML__` (render as compact `<p>` lines with `&bull;`, not `<ul><li>`)
+- `__BODY_SECTIONS_HTML__`
+- `__CTA_HEADING__`
+- `__CTA_PRIMARY_TEXT__`
+- `__CTA_SECONDARY_TEXT__`
+- `__QR_URL__`
+- `__QR_ALT__`
+- `__FOOTER_HTML__`
+
+Keep placeholders explicit and content-shaped so they can be replaced by simple text processing.

--- a/skills/md2wechat/templates/event-blue-card-inline.html.tmpl
+++ b/skills/md2wechat/templates/event-blue-card-inline.html.tmpl
@@ -1,0 +1,31 @@
+<section style="margin:0 auto;max-width:720px;padding:24px 16px;background-color:#f7f8fc;">
+  <section style="background:#ffffff;border-radius:18px;padding:28px 22px;box-shadow:0 8px 24px rgba(50,70,120,0.08);border:1px solid #e6ebff;">
+    <p style="margin:0 0 12px 0;font-size:12px;line-height:1.8;color:#5b66a3;letter-spacing:1px;">__EYEBROW__</p>
+    <h1 style="margin:0 0 14px 0;font-size:28px;line-height:1.4;color:#1f2f6b;">__TITLE__</h1>
+    <p style="margin:0;font-size:15px;line-height:1.9;color:#4f5d7a;">__SUMMARY__</p>
+  </section>
+
+  <section style="margin-top:18px;background:linear-gradient(135deg,#eef2ff 0%,#f7fbff 100%);border:1px solid #dfe7ff;border-radius:18px;padding:22px;">
+    <p style="margin:0 0 8px 0;font-size:18px;line-height:1.6;color:#243b8f;"><strong>__OVERVIEW_LABEL__</strong></p>
+    <p style="margin:0;font-size:14px;line-height:2;color:#44516f;">__OVERVIEW_HTML__</p>
+  </section>
+
+  <section style="margin-top:18px;background:#ffffff;border-radius:18px;padding:24px 22px;border:1px solid #e6ebff;">
+    <h2 style="margin:0 0 14px 0;font-size:20px;line-height:1.5;color:#243b8f;">__INFO_HEADING__</h2>
+    __INFO_LIST_HTML__
+  </section>
+
+  __BODY_SECTIONS_HTML__
+
+  <section style="margin-top:18px;background:linear-gradient(135deg,#f4f7ff 0%,#ffffff 100%);border:1px solid #dfe7ff;border-radius:18px;padding:24px 22px;text-align:center;">
+    <h2 style="margin:0 0 14px 0;font-size:20px;line-height:1.5;color:#243b8f;">__CTA_HEADING__</h2>
+    <p style="margin:0 0 12px 0;font-size:15px;line-height:1.9;color:#44516f;">__CTA_PRIMARY_TEXT__</p>
+    <p style="margin:0 0 16px 0;font-size:15px;line-height:1.9;color:#2f4eb4;">__CTA_SECONDARY_TEXT__</p>
+    <img src="__QR_URL__" alt="__QR_ALT__" style="display:block;width:72%;max-width:320px;margin:0 auto 16px auto;border-radius:12px;">
+    <p style="margin:0;font-size:14px;line-height:1.9;color:#44516f;">__CTA_FOOTNOTE__</p>
+  </section>
+
+  <section style="margin-top:18px;padding:12px 6px 4px 6px;text-align:center;">
+    <p style="margin:0;font-size:14px;line-height:2;color:#6b728a;">__FOOTER_HTML__</p>
+  </section>
+</section>


### PR DESCRIPTION
## Summary
- add update_draft <media_id> <json_file> --index <n> for updating an existing WeChat draft article
- post to WeChat /cgi-bin/draft/update and return the existing media_id on success
- document the existing-draft-first workflow in embedded and OpenClaw skills

## Tests
- go test ./...
