### PR TITLE
feat(image): add MiniMax subject references

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,16 @@ md2wechat generate_infographic --article article.md --preset infographic-claude-
 
 完整 preset 清单、用途和默认画幅以 `prompts list/show --json` 为准，文档只保留代表性示例。
 
-支持 Volcengine、ModelScope、OpenRouter、OpenAI、Gemini 等服务。配置见 [docs/IMAGE_PROVISIONERS.md](docs/IMAGE_PROVISIONERS.md)。
+支持 Volcengine、ModelScope、OpenRouter、OpenAI、Gemini、MiniMax 等服务。配置见 [docs/IMAGE_PROVISIONERS.md](docs/IMAGE_PROVISIONERS.md)。
+
+需要在生成结果中保持同一人物形象时，可以用 MiniMax 的主体参考（图生图）：
+
+```bash
+md2wechat generate_image "保持同一人物形象的秋日封面" \
+  --subject-reference "https://cdn.example.com/portrait.png"
+```
+
+`--subject-reference` 只支持 `minimax` provider 的 `image-01` 模型，参考图必须是可公开访问的 `http(s)` 图片 URL。
 
 使用宿主 Agent 的 Image Gen：
 

--- a/cmd/md2wechat/convert.go
+++ b/cmd/md2wechat/convert.go
@@ -25,6 +25,10 @@ type imageProcessor interface {
 	GenerateAndUploadWithSize(prompt string, size string) (*image.GenerateAndUploadResult, error)
 }
 
+type subjectReferenceImageProcessor interface {
+	GenerateAndUploadWithSubject(prompt, subjectReference string) (*image.GenerateAndUploadResult, error)
+}
+
 var (
 	newMarkdownConverter = func() converter.Converter {
 		return converter.NewConverter(cfg, log)

--- a/cmd/md2wechat/discovery.go
+++ b/cmd/md2wechat/discovery.go
@@ -23,26 +23,28 @@ const (
 )
 
 type providerView struct {
-	Name            string                    `json:"name"`
-	Aliases         []string                  `json:"aliases,omitempty"`
-	Description     string                    `json:"description"`
-	RequiredConfig  []string                  `json:"required_config,omitempty"`
-	OptionalConfig  []string                  `json:"optional_config,omitempty"`
-	DefaultBaseURL  string                    `json:"default_base_url,omitempty"`
-	DefaultModel    string                    `json:"default_model,omitempty"`
-	SupportedModels []image.ProviderModelMeta `json:"supported_models,omitempty"`
-	SupportsSize    bool                      `json:"supports_size"`
-	Current         bool                      `json:"current"`
-	Configured      bool                      `json:"configured"`
+	Name                     string                    `json:"name"`
+	Aliases                  []string                  `json:"aliases,omitempty"`
+	Description              string                    `json:"description"`
+	RequiredConfig           []string                  `json:"required_config,omitempty"`
+	OptionalConfig           []string                  `json:"optional_config,omitempty"`
+	DefaultBaseURL           string                    `json:"default_base_url,omitempty"`
+	DefaultModel             string                    `json:"default_model,omitempty"`
+	SupportedModels          []image.ProviderModelMeta `json:"supported_models,omitempty"`
+	SupportsSize             bool                      `json:"supports_size"`
+	SupportsSubjectReference bool                      `json:"supports_subject_reference"`
+	Current                  bool                      `json:"current"`
+	Configured               bool                      `json:"configured"`
 }
 
 type providerListItem struct {
-	Name         string   `json:"name"`
-	Aliases      []string `json:"aliases,omitempty"`
-	Description  string   `json:"description"`
-	SupportsSize bool     `json:"supports_size"`
-	Current      bool     `json:"current"`
-	Configured   bool     `json:"configured"`
+	Name                     string   `json:"name"`
+	Aliases                  []string `json:"aliases,omitempty"`
+	Description              string   `json:"description"`
+	SupportsSize             bool     `json:"supports_size"`
+	SupportsSubjectReference bool     `json:"supports_subject_reference"`
+	Current                  bool     `json:"current"`
+	Configured               bool     `json:"configured"`
 }
 
 type themeView struct {
@@ -306,17 +308,18 @@ func buildProviderViews() ([]providerView, error) {
 	for _, meta := range image.SupportedProviders() {
 		current := meta.Name == currentProvider || contains(meta.Aliases, currentProvider)
 		result = append(result, providerView{
-			Name:            meta.Name,
-			Aliases:         meta.Aliases,
-			Description:     meta.Description,
-			RequiredConfig:  meta.RequiredConfig,
-			OptionalConfig:  meta.OptionalConfig,
-			DefaultBaseURL:  meta.DefaultBaseURL,
-			DefaultModel:    meta.DefaultModel,
-			SupportedModels: meta.SupportedModels,
-			SupportsSize:    meta.SupportsSize,
-			Current:         current,
-			Configured:      current && hasAPIKey,
+			Name:                     meta.Name,
+			Aliases:                  meta.Aliases,
+			Description:              meta.Description,
+			RequiredConfig:           meta.RequiredConfig,
+			OptionalConfig:           meta.OptionalConfig,
+			DefaultBaseURL:           meta.DefaultBaseURL,
+			DefaultModel:             meta.DefaultModel,
+			SupportedModels:          meta.SupportedModels,
+			SupportsSize:             meta.SupportsSize,
+			SupportsSubjectReference: meta.SupportsSubjectReference,
+			Current:                  current,
+			Configured:               current && hasAPIKey,
 		})
 	}
 	return result, nil
@@ -324,12 +327,13 @@ func buildProviderViews() ([]providerView, error) {
 
 func providerToListItem(provider providerView) providerListItem {
 	return providerListItem{
-		Name:         provider.Name,
-		Aliases:      provider.Aliases,
-		Description:  provider.Description,
-		SupportsSize: provider.SupportsSize,
-		Current:      provider.Current,
-		Configured:   provider.Configured,
+		Name:                     provider.Name,
+		Aliases:                  provider.Aliases,
+		Description:              provider.Description,
+		SupportsSize:             provider.SupportsSize,
+		SupportsSubjectReference: provider.SupportsSubjectReference,
+		Current:                  provider.Current,
+		Configured:               provider.Configured,
 	}
 }
 

--- a/cmd/md2wechat/discovery_test.go
+++ b/cmd/md2wechat/discovery_test.go
@@ -1464,3 +1464,79 @@ func TestPromptsListIncludesVictorianBannerByTag(t *testing.T) {
 		t.Fatalf("expected infographic-victorian-engraving-banner in response: %#v", prompts)
 	}
 }
+
+// TestProvidersExposeSubjectReferenceCapability asserts the subject reference
+// capability reaches both providers list --json and providers show --json.
+func TestProvidersExposeSubjectReferenceCapability(t *testing.T) {
+	oldCfg, oldJSON := cfg, jsonOutput
+	t.Cleanup(func() {
+		cfg, jsonOutput = oldCfg, oldJSON
+	})
+
+	cfg = &config.Config{ImageProvider: "minimax", ImageAPIKey: "configured-key"}
+	jsonOutput = true
+
+	listOutput := captureStdout(t, func() {
+		if err := providersListCmd.RunE(providersListCmd, nil); err != nil {
+			t.Fatalf("providers list: %v", err)
+		}
+	})
+	var listResponse struct {
+		Data struct {
+			Providers []providerListItem `json:"providers"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(listOutput, &listResponse); err != nil {
+		t.Fatalf("decode providers list: %v\n%s", err, listOutput)
+	}
+	if !bytes.Contains(listOutput, []byte(`"supports_subject_reference"`)) {
+		t.Fatalf("providers list must expose supports_subject_reference\n%s", listOutput)
+	}
+	var seenMiniMax bool
+	for _, provider := range listResponse.Data.Providers {
+		switch provider.Name {
+		case "minimax":
+			seenMiniMax = true
+			if !provider.SupportsSubjectReference {
+				t.Fatalf("minimax list item = %#v, want supports_subject_reference true", provider)
+			}
+		default:
+			if provider.SupportsSubjectReference {
+				t.Fatalf("provider %q must not advertise subject reference support", provider.Name)
+			}
+		}
+	}
+	if !seenMiniMax {
+		t.Fatal("providers list is missing minimax")
+	}
+
+	showOutput := captureStdout(t, func() {
+		if err := providersShowCmd.RunE(providersShowCmd, []string{"minimax"}); err != nil {
+			t.Fatalf("providers show: %v", err)
+		}
+	})
+	var showResponse struct {
+		Data struct {
+			Provider providerView `json:"provider"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(showOutput, &showResponse); err != nil {
+		t.Fatalf("decode provider show: %v\n%s", err, showOutput)
+	}
+	provider := showResponse.Data.Provider
+	if !provider.SupportsSubjectReference {
+		t.Fatalf("shown provider = %#v, want supports_subject_reference true", provider)
+	}
+	if provider.DefaultBaseURL != "https://api.minimax.io" || provider.DefaultModel != "image-01" {
+		t.Fatalf("shown provider defaults = %q / %q", provider.DefaultBaseURL, provider.DefaultModel)
+	}
+	var subjectModels []string
+	for _, model := range provider.SupportedModels {
+		if model.SupportsSubjectReference {
+			subjectModels = append(subjectModels, model.Name)
+		}
+	}
+	if len(subjectModels) != 1 || subjectModels[0] != "image-01" {
+		t.Fatalf("models advertising subject reference support = %#v", subjectModels)
+	}
+}

--- a/cmd/md2wechat/generate_image.go
+++ b/cmd/md2wechat/generate_image.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/geekjourneyx/md2wechat-skill/internal/config"
 	"github.com/geekjourneyx/md2wechat-skill/internal/converter"
+	"github.com/geekjourneyx/md2wechat-skill/internal/image"
 	"github.com/geekjourneyx/md2wechat-skill/internal/promptcatalog"
 )
 
@@ -134,8 +135,15 @@ func runGenerateImageWithInput(input generateImageInput) error {
 		return newCLIError(codeConfigInvalid, err.Error())
 	}
 
+	subjectReference := strings.TrimSpace(input.SubjectReference)
+	if subjectReference != "" {
+		if err := ensureSubjectReferenceSupported(input.Model, subjectReference); err != nil {
+			return err
+		}
+	}
+
 	processor := resolveImageProcessor(input.Model)
-	if strings.TrimSpace(input.SubjectReference) != "" {
+	if subjectReference != "" {
 		if strings.TrimSpace(input.Size) != "" {
 			cfgCopy := *cfg
 			cfgCopy.ImageSize = strings.TrimSpace(input.Size)
@@ -146,9 +154,9 @@ func runGenerateImageWithInput(input generateImageInput) error {
 		}
 		subjectProcessor, ok := processor.(subjectReferenceImageProcessor)
 		if !ok {
-			return newCLIError(codeConfigInvalid, "configured image provider does not support --subject-reference")
+			return newCLIError(codeConfigInvalid, "configured image processor does not support --subject-reference")
 		}
-		result, err := subjectProcessor.GenerateAndUploadWithSubject(prompt, strings.TrimSpace(input.SubjectReference))
+		result, err := subjectProcessor.GenerateAndUploadWithSubject(prompt, subjectReference)
 		if err != nil {
 			return wrapCLIError(codeImageGenerateFailed, err, err.Error())
 		}
@@ -181,6 +189,57 @@ func resolveImageProcessor(model string) imageProcessor {
 	cfgCopy := *cfg
 	cfgCopy.ImageModel = model
 	return newImageProcessorWithConfig(&cfgCopy)
+}
+
+// resolveImageProviderName returns the configured image provider, falling back
+// to the same default the provider factory uses.
+func resolveImageProviderName() string {
+	provider := strings.TrimSpace(cfg.ImageProvider)
+	if provider == "" {
+		provider = "openai"
+	}
+	return provider
+}
+
+// resolveImageModelName returns the model this command will actually use,
+// honouring --model first, then the config, then the provider default.
+func resolveImageModelName(provider, override string) string {
+	if model := strings.TrimSpace(override); model != "" {
+		return model
+	}
+	if model := strings.TrimSpace(cfg.ImageModel); model != "" {
+		return model
+	}
+	return image.DefaultProviderModel(provider)
+}
+
+// ensureSubjectReferenceSupported rejects --subject-reference from provider
+// metadata. A runtime interface assertion cannot do this because the concrete
+// processor always implements the subject-reference method regardless of the
+// configured provider, which would defer the failure to the generate call.
+func ensureSubjectReferenceSupported(modelOverride, subjectReference string) error {
+	if err := image.ValidateSubjectReferenceURL(subjectReference); err != nil {
+		return newCLIError(codeConfigInvalid, err.Error())
+	}
+
+	provider := resolveImageProviderName()
+	if !image.ProviderSupportsSubjectReference(provider) {
+		message := fmt.Sprintf("image provider %s does not support --subject-reference", provider)
+		if supported := image.SubjectReferenceProviderNames(); len(supported) > 0 {
+			message += "; supported providers: " + strings.Join(supported, ", ")
+		}
+		return newCLIError(codeConfigInvalid, message)
+	}
+
+	model := resolveImageModelName(provider, modelOverride)
+	if !image.ModelSupportsSubjectReference(provider, model) {
+		message := fmt.Sprintf("image model %s does not support --subject-reference", model)
+		if hint := image.SubjectReferenceModelsHint(provider); hint != "" {
+			message += "; " + hint
+		}
+		return newCLIError(codeConfigInvalid, message)
+	}
+	return nil
 }
 
 func resolveGenerateImagePrompt(input generateImageInput) (string, error) {

--- a/cmd/md2wechat/generate_image.go
+++ b/cmd/md2wechat/generate_image.go
@@ -20,6 +20,7 @@ var (
 	generateImageCmdKeywords string
 	generateImageCmdStyle    string
 	generateImageCmdAspect   string
+	generateImageCmdSubject  string
 	generateImageCmdPlan     bool
 )
 
@@ -36,6 +37,7 @@ type generateImageInput struct {
 	Aspect            string
 	Size              string
 	Model             string
+	SubjectReference  string
 	RequiredArchetype string
 }
 
@@ -77,23 +79,25 @@ type generateImagePlan struct {
 	Aspect                  string   `json:"aspect"`
 	Size                    string   `json:"size"`
 	ModelHint               string   `json:"model_hint"`
+	SubjectReference        string   `json:"subject_reference,omitempty"`
 	SuggestedFilename       string   `json:"suggested_filename"`
 	AltText                 string   `json:"alt_text"`
 }
 
 func runGenerateImage(args []string) error {
 	input := generateImageInput{
-		Command:  "generate_image",
-		Plan:     generateImageCmdPlan,
-		Preset:   generateImageCmdPreset,
-		Article:  generateImageCmdArticle,
-		Title:    generateImageCmdTitle,
-		Summary:  generateImageCmdSummary,
-		Keywords: generateImageCmdKeywords,
-		Style:    generateImageCmdStyle,
-		Aspect:   generateImageCmdAspect,
-		Size:     generateImageCmdSize,
-		Model:    generateImageCmdModel,
+		Command:          "generate_image",
+		Plan:             generateImageCmdPlan,
+		Preset:           generateImageCmdPreset,
+		Article:          generateImageCmdArticle,
+		Title:            generateImageCmdTitle,
+		Summary:          generateImageCmdSummary,
+		Keywords:         generateImageCmdKeywords,
+		Style:            generateImageCmdStyle,
+		Aspect:           generateImageCmdAspect,
+		Size:             generateImageCmdSize,
+		Model:            generateImageCmdModel,
+		SubjectReference: generateImageCmdSubject,
 	}
 	if len(args) > 0 {
 		input.RawPrompt = args[0]
@@ -131,6 +135,26 @@ func runGenerateImageWithInput(input generateImageInput) error {
 	}
 
 	processor := resolveImageProcessor(input.Model)
+	if strings.TrimSpace(input.SubjectReference) != "" {
+		if strings.TrimSpace(input.Size) != "" {
+			cfgCopy := *cfg
+			cfgCopy.ImageSize = strings.TrimSpace(input.Size)
+			if strings.TrimSpace(input.Model) != "" {
+				cfgCopy.ImageModel = strings.TrimSpace(input.Model)
+			}
+			processor = newImageProcessorWithConfig(&cfgCopy)
+		}
+		subjectProcessor, ok := processor.(subjectReferenceImageProcessor)
+		if !ok {
+			return newCLIError(codeConfigInvalid, "configured image provider does not support --subject-reference")
+		}
+		result, err := subjectProcessor.GenerateAndUploadWithSubject(prompt, strings.TrimSpace(input.SubjectReference))
+		if err != nil {
+			return wrapCLIError(codeImageGenerateFailed, err, err.Error())
+		}
+		responseSuccess(result)
+		return nil
+	}
 	if input.Size != "" {
 		result, err := processor.GenerateAndUploadWithSize(prompt, input.Size)
 		if err != nil {
@@ -252,6 +276,7 @@ func buildGenerateImagePlan(input generateImageInput, resolved *generateImagePro
 		Aspect:                  strings.TrimSpace(resolved.Aspect),
 		Size:                    strings.TrimSpace(input.Size),
 		ModelHint:               strings.TrimSpace(input.Model),
+		SubjectReference:        strings.TrimSpace(input.SubjectReference),
 		CompatibleUseCases:      []string{},
 		RecommendedAspectRatios: []string{},
 	}

--- a/cmd/md2wechat/generate_image_test.go
+++ b/cmd/md2wechat/generate_image_test.go
@@ -12,6 +12,47 @@ import (
 	"github.com/geekjourneyx/md2wechat-skill/internal/promptcatalog"
 )
 
+type fakeSubjectReferenceProcessor struct {
+	*fakeImageProcessor
+	prompt    string
+	reference string
+	result    *image.GenerateAndUploadResult
+}
+
+func (f *fakeSubjectReferenceProcessor) GenerateAndUploadWithSubject(prompt, subjectReference string) (*image.GenerateAndUploadResult, error) {
+	f.prompt = prompt
+	f.reference = subjectReference
+	return f.result, nil
+}
+
+func TestRunGenerateImageWithSubjectReference(t *testing.T) {
+	oldCfg := cfg
+	oldNewImageProcessor := newImageProcessor
+	t.Cleanup(func() {
+		cfg = oldCfg
+		newImageProcessor = oldNewImageProcessor
+	})
+	cfg = &config.Config{WechatAppID: "appid", WechatSecret: "secret", ImageAPIKey: "image-key"}
+	processor := &fakeSubjectReferenceProcessor{
+		fakeImageProcessor: &fakeImageProcessor{},
+		result:             &image.GenerateAndUploadResult{MediaID: "media-subject"},
+	}
+	newImageProcessor = func() imageProcessor { return processor }
+
+	if err := runGenerateImageWithInput(generateImageInput{
+		RawPrompt:        "Keep the portrait identity",
+		SubjectReference: "https://cdn.example/portrait.png",
+	}); err != nil {
+		t.Fatalf("runGenerateImageWithInput() error = %v", err)
+	}
+	if processor.prompt != "Keep the portrait identity" {
+		t.Fatalf("prompt = %q", processor.prompt)
+	}
+	if processor.reference != "https://cdn.example/portrait.png" {
+		t.Fatalf("reference = %q", processor.reference)
+	}
+}
+
 func TestResolveGenerateImagePromptRendersPlanVisualAssetPresets(t *testing.T) {
 	promptcatalog.ResetDefaultCatalogForTests()
 	t.Cleanup(promptcatalog.ResetDefaultCatalogForTests)

--- a/cmd/md2wechat/generate_image_test.go
+++ b/cmd/md2wechat/generate_image_test.go
@@ -32,7 +32,10 @@ func TestRunGenerateImageWithSubjectReference(t *testing.T) {
 		cfg = oldCfg
 		newImageProcessor = oldNewImageProcessor
 	})
-	cfg = &config.Config{WechatAppID: "appid", WechatSecret: "secret", ImageAPIKey: "image-key"}
+	cfg = &config.Config{
+		WechatAppID: "appid", WechatSecret: "secret", ImageAPIKey: "image-key",
+		ImageProvider: "minimax", ImageModel: "image-01",
+	}
 	processor := &fakeSubjectReferenceProcessor{
 		fakeImageProcessor: &fakeImageProcessor{},
 		result:             &image.GenerateAndUploadResult{MediaID: "media-subject"},
@@ -47,6 +50,166 @@ func TestRunGenerateImageWithSubjectReference(t *testing.T) {
 	}
 	if processor.prompt != "Keep the portrait identity" {
 		t.Fatalf("prompt = %q", processor.prompt)
+	}
+	if processor.reference != "https://cdn.example/portrait.png" {
+		t.Fatalf("reference = %q", processor.reference)
+	}
+}
+
+// TestRunGenerateImageSubjectReferenceUsesProviderMetadata asserts the CLI
+// rejects --subject-reference from provider metadata. The runtime processor
+// always implements the subject-reference method, so an interface assertion
+// alone would let unsupported providers fail late as IMAGE_GENERATE_FAILED.
+func TestRunGenerateImageSubjectReferenceUsesProviderMetadata(t *testing.T) {
+	cases := []struct {
+		name     string
+		provider string
+		model    string
+		override string
+		wantText string
+	}{
+		{name: "unsupported_provider", provider: "openai", model: "gpt-image-2", wantText: "provider openai does not support"},
+		{name: "default_provider", provider: "", wantText: "provider openai does not support"},
+		{name: "unsupported_model", provider: "minimax", model: "image-01-live", wantText: "model image-01-live does not support"},
+		{name: "unsupported_model_override", provider: "minimax", model: "image-01", override: "image-01-live", wantText: "model image-01-live does not support"},
+		{name: "unknown_model", provider: "minimax", model: "image-99", wantText: "model image-99 does not support"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			oldCfg := cfg
+			oldNewImageProcessor, oldNewImageProcessorWithConfig := newImageProcessor, newImageProcessorWithConfig
+			t.Cleanup(func() {
+				cfg = oldCfg
+				newImageProcessor = oldNewImageProcessor
+				newImageProcessorWithConfig = oldNewImageProcessorWithConfig
+			})
+			cfg = &config.Config{
+				WechatAppID: "appid", WechatSecret: "secret", ImageAPIKey: "image-key",
+				ImageProvider: testCase.provider, ImageModel: testCase.model,
+			}
+			processor := &fakeSubjectReferenceProcessor{
+				fakeImageProcessor: &fakeImageProcessor{},
+				result:             &image.GenerateAndUploadResult{MediaID: "media-subject"},
+			}
+			newImageProcessor = func() imageProcessor { return processor }
+			newImageProcessorWithConfig = func(*config.Config) imageProcessor { return processor }
+
+			err := runGenerateImageWithInput(generateImageInput{
+				RawPrompt:        "Keep the portrait identity",
+				SubjectReference: "https://cdn.example/portrait.png",
+				Model:            testCase.override,
+			})
+			if err == nil {
+				t.Fatal("expected --subject-reference to be rejected")
+			}
+			if !strings.Contains(err.Error(), testCase.wantText) {
+				t.Fatalf("error = %v, want it to mention %q", err, testCase.wantText)
+			}
+			cliErr, ok := extractCLIError(err)
+			if !ok {
+				t.Fatalf("error %v is not a *cliError", err)
+			}
+			if cliErr.Code != codeConfigInvalid {
+				t.Fatalf("error code = %q, want %q", cliErr.Code, codeConfigInvalid)
+			}
+			if processor.reference != "" {
+				t.Fatalf("processor must not be called, got reference %q", processor.reference)
+			}
+		})
+	}
+}
+
+// TestRunGenerateImageRejectsInvalidSubjectReferenceURLs keeps unusable
+// references out of the provider call and reports them as invalid configuration.
+func TestRunGenerateImageRejectsInvalidSubjectReferenceURLs(t *testing.T) {
+	cases := []struct {
+		name      string
+		reference string
+	}{
+		{name: "data_url", reference: "data:image/jpeg;base64,QUJD"},
+		{name: "local_path", reference: "/tmp/portrait.png"},
+		{name: "relative_path", reference: "portrait.png"},
+		{name: "unsupported_scheme", reference: "ftp://cdn.example/portrait.png"},
+		{name: "missing_host", reference: "https://"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			oldCfg := cfg
+			oldNewImageProcessor, oldNewImageProcessorWithConfig := newImageProcessor, newImageProcessorWithConfig
+			t.Cleanup(func() {
+				cfg = oldCfg
+				newImageProcessor = oldNewImageProcessor
+				newImageProcessorWithConfig = oldNewImageProcessorWithConfig
+			})
+			cfg = &config.Config{
+				WechatAppID: "appid", WechatSecret: "secret", ImageAPIKey: "image-key",
+				ImageProvider: "minimax", ImageModel: "image-01",
+			}
+			newImageProcessor = func() imageProcessor {
+				t.Fatal("processor must not be built for an invalid subject reference")
+				return nil
+			}
+			newImageProcessorWithConfig = func(*config.Config) imageProcessor {
+				t.Fatal("processor must not be built for an invalid subject reference")
+				return nil
+			}
+
+			err := runGenerateImageWithInput(generateImageInput{
+				RawPrompt:        "Keep the portrait identity",
+				SubjectReference: testCase.reference,
+			})
+			cliErr, ok := extractCLIError(err)
+			if !ok {
+				t.Fatalf("error %v is not a *cliError", err)
+			}
+			if cliErr.Code != codeConfigInvalid {
+				t.Fatalf("error code = %q, want %q", cliErr.Code, codeConfigInvalid)
+			}
+		})
+	}
+}
+
+// TestRunGenerateImageSubjectReferenceHonoursSizeAndModelOverrides checks the
+// runtime config copy used when --size is combined with --subject-reference.
+func TestRunGenerateImageSubjectReferenceHonoursSizeAndModelOverrides(t *testing.T) {
+	oldCfg := cfg
+	oldNewImageProcessor, oldNewImageProcessorWithConfig := newImageProcessor, newImageProcessorWithConfig
+	t.Cleanup(func() {
+		cfg = oldCfg
+		newImageProcessor = oldNewImageProcessor
+		newImageProcessorWithConfig = oldNewImageProcessorWithConfig
+	})
+	cfg = &config.Config{
+		WechatAppID: "appid", WechatSecret: "secret", ImageAPIKey: "image-key",
+		ImageProvider: "minimax", ImageModel: "image-01-live",
+	}
+	processor := &fakeSubjectReferenceProcessor{
+		fakeImageProcessor: &fakeImageProcessor{},
+		result:             &image.GenerateAndUploadResult{MediaID: "media-subject"},
+	}
+	var runtimeCfg *config.Config
+	newImageProcessor = func() imageProcessor { return processor }
+	newImageProcessorWithConfig = func(candidate *config.Config) imageProcessor {
+		runtimeCfg = candidate
+		return processor
+	}
+
+	if err := runGenerateImageWithInput(generateImageInput{
+		RawPrompt:        "Keep the portrait identity",
+		SubjectReference: "https://cdn.example/portrait.png",
+		Model:            "image-01",
+		Size:             "1024x768",
+	}); err != nil {
+		t.Fatalf("runGenerateImageWithInput() error = %v", err)
+	}
+	if runtimeCfg == nil {
+		t.Fatal("expected a runtime config copy for the size override")
+	}
+	if runtimeCfg.ImageSize != "1024x768" || runtimeCfg.ImageModel != "image-01" {
+		t.Fatalf("runtime config size/model = %q/%q", runtimeCfg.ImageSize, runtimeCfg.ImageModel)
+	}
+	if cfg.ImageSize != "" || cfg.ImageModel != "image-01-live" {
+		t.Fatalf("global config was mutated: size %q model %q", cfg.ImageSize, cfg.ImageModel)
 	}
 	if processor.reference != "https://cdn.example/portrait.png" {
 		t.Fatalf("reference = %q", processor.reference)

--- a/cmd/md2wechat/main.go
+++ b/cmd/md2wechat/main.go
@@ -462,7 +462,7 @@ Examples:
 	generateImageCmd.Flags().StringVar(&generateImageCmdStyle, "style", "", "Visual style used to render a preset prompt")
 	generateImageCmd.Flags().StringVar(&generateImageCmdAspect, "aspect", "", "Aspect ratio hint used to render a preset prompt, e.g. 16:9 or 3:4")
 	generateImageCmd.Flags().StringVar(&generateImageCmdModel, "model", "", "Image model to use for this command (overrides IMAGE_MODEL and api.image_model)")
-	generateImageCmd.Flags().StringVar(&generateImageCmdSubject, "subject-reference", "", "Public URL or image data URL used as a character reference")
+	generateImageCmd.Flags().StringVar(&generateImageCmdSubject, "subject-reference", "", "Public http(s) portrait image URL used as a character reference (minimax image-01 only)")
 	generateImageCmd.Flags().BoolVar(&generateImageCmdPlan, "plan", false, "Render an image generation plan without provider or upload side effects")
 	addRootCommands(rootCmd)
 

--- a/cmd/md2wechat/main.go
+++ b/cmd/md2wechat/main.go
@@ -462,6 +462,7 @@ Examples:
 	generateImageCmd.Flags().StringVar(&generateImageCmdStyle, "style", "", "Visual style used to render a preset prompt")
 	generateImageCmd.Flags().StringVar(&generateImageCmdAspect, "aspect", "", "Aspect ratio hint used to render a preset prompt, e.g. 16:9 or 3:4")
 	generateImageCmd.Flags().StringVar(&generateImageCmdModel, "model", "", "Image model to use for this command (overrides IMAGE_MODEL and api.image_model)")
+	generateImageCmd.Flags().StringVar(&generateImageCmdSubject, "subject-reference", "", "Public URL or image data URL used as a character reference")
 	generateImageCmd.Flags().BoolVar(&generateImageCmdPlan, "plan", false, "Render an image generation plan without provider or upload side effects")
 	addRootCommands(rootCmd)
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -381,9 +381,11 @@ image:
 | `api.image_provider` | 否 | 图片服务提供方 | `openai` |
 | `api.image_base_url` | 否 | 图片服务地址 | `https://api.openai.com/v1` |
 | `api.image_model` | 否 | 图片模型 | `gpt-image-2` |
-| `api.image_size` | 否 | 默认图片执行尺寸/宽高比 | 跟随当前 provider，例如 `openai=auto`、`volcengine=2K` |
+| `api.image_size` | 否 | 默认图片执行尺寸/宽高比 | 跟随当前 provider，例如 `openai=auto`、`volcengine=2K`、`minimax=1:1` |
 
-当前内置 provider：`openai`、`tuzi`、`modelscope` (`ms`)、`openrouter` (`or`)、`gemini` (`google`)、`volcengine` (`volc`)。
+当前内置 provider：`openai`、`minimax`、`tuzi`、`modelscope` (`ms`)、`openrouter` (`or`)、`gemini` (`google`)、`volcengine` (`volc`)。
+
+`minimax` 的默认值为 `image_base_url=https://api.minimax.io`（国内站为 `https://api.minimaxi.com`）、`image_model=image-01`、`image_size=1:1`。它也是当前唯一支持 `--subject-reference` 主体参考的 provider，且只有 `image-01` 支持该参数。详见 [图片生成服务配置](IMAGE_PROVISIONERS.md)。
 
 ### 图片处理配置
 

--- a/docs/DISCOVERY.md
+++ b/docs/DISCOVERY.md
@@ -144,6 +144,7 @@ md2wechat providers list --json
 md2wechat providers show openai --json
 md2wechat providers show openrouter --json
 md2wechat providers show volcengine --json
+md2wechat providers show minimax --json
 ```
 
 `providers list --json` 只返回选择下一条命令所需的轻量元数据：
@@ -152,6 +153,7 @@ md2wechat providers show volcengine --json
 - `aliases`
 - `description`
 - `supports_size`
+- `supports_subject_reference`
 - `current`
 - `configured`
 
@@ -163,16 +165,21 @@ md2wechat providers show volcengine --json
 - `default_model`
 - `supported_models`
 
+`supported_models` 中的每个模型也会带上 `supports_subject_reference`，用于判断哪些模型可以配合 `--subject-reference` 使用。
+
 因此，Agent 应先用 `list` 选择 provider，只在准备配置或调用具体 provider 时读取 `show`，避免在枚举阶段加载完整模型表。
 
 当前内置支持的图片 provider：
 
 - `openai`
+- `minimax`
 - `tuzi`
 - `modelscope` / `ms`
 - `openrouter` / `or`
 - `gemini` / `google`
 - `volcengine` / `volc`
+
+其中只有 `minimax` 的 `supports_subject_reference` 为 `true`，对应模型为 `image-01`。
 
 ## 主题发现
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -597,6 +597,8 @@ md2wechat config show --format json
 
 如果是 MiniMax，错误信息里会带上上游 `base_resp.status_code`：`1004` / `2049` 是 API Key 问题，`1002` 是限流，`1008` 是余额不足，`1026` 是提示词命中内容安全策略，`2013` 是参数错误。全球站与国内站的 `image_base_url` 不同，分别是 `https://api.minimax.io` 和 `https://api.minimaxi.com`。
 
+MiniMax status code `1027` indicates that generated output was blocked by content safety policy and maps to `safety_blocked`.
+
 然后再试最小命令：
 
 ```bash

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -595,6 +595,8 @@ md2wechat config show --format json
 
 如果是 Volcengine 返回 `ModelNotOpen`，去 [豆包大模型](https://www.volcengine.com/product/doubao) 点击“控制台” -> “开通管理”，勾选 `Seedream` 模型完成开通，再重试。
 
+如果是 MiniMax，错误信息里会带上上游 `base_resp.status_code`：`1004` / `2049` 是 API Key 问题，`1002` 是限流，`1008` 是余额不足，`1026` 是提示词命中内容安全策略，`2013` 是参数错误。全球站与国内站的 `image_base_url` 不同，分别是 `https://api.minimax.io` 和 `https://api.minimaxi.com`。
+
 然后再试最小命令：
 
 ```bash
@@ -619,7 +621,32 @@ md2wechat generate_cover --article article.md --plan --json
 
 返回里的 `requires_provider:false` 和 `requires_image_api_key:false` 表示 md2wechat 这一侧不需要图片服务配置。真正的图片文件只有在宿主 Agent 调用 Image Gen 并保存后才会出现。完整流程见 [Agent 图片计划模式](AGENT_IMAGE_GEN.md)。
 
-### Q14.2：`advise` 和 `inspect` 有什么区别？
+### Q14.2：怎么在生成图片时保持同一人物形象？
+
+用 MiniMax 的主体参考（图生图）：
+
+```bash
+md2wechat generate_image "保持同一人物形象的秋日封面" \
+  --subject-reference "https://cdn.example.com/portrait.png"
+```
+
+注意事项：
+
+- 只有 `minimax` provider 支持 `--subject-reference`，其他 provider 会立即返回 `CONFIG_INVALID`，不会发起生成请求
+- 只有 `image-01` 支持该参数，`image-01-live` 会被直接拒绝
+- 参考图必须是可公开访问的 `http://` 或 `https://` 图片 URL，当前不支持内联 data URL 和本地路径
+- 建议使用单人正脸照片，格式 `JPG` / `JPEG` / `PNG`
+- 可以和 `--size`、`--model` 组合使用
+
+想确认当前 CLI 是否识别到该能力：
+
+```bash
+md2wechat providers show minimax --json
+```
+
+看返回里的 `supports_subject_reference`，以及 `supported_models` 中每个模型的 `supports_subject_reference`。
+
+### Q14.3：`advise` 和 `inspect` 有什么区别？
 
 `inspect` 是发布前 readiness 真相源，回答“能不能继续 convert/upload/draft”。`advise` 是可选增强建议，回答“这篇已有文章是否值得最小改动地加标题建议、封面计划、layout 模块或微调”。如果 `inspect` 的目标是 `blocked`，先修 blocker，不要用 `advise` 绕过发布前检查。
 

--- a/docs/IMAGE_PROVISIONERS.md
+++ b/docs/IMAGE_PROVISIONERS.md
@@ -18,7 +18,7 @@ md2wechat 支持多种图片生成服务，可以在 Markdown 中使用 AI 生�
 
 ```yaml
 api:
-  # 图片服务提供者: openai, tuzi, modelscope, openrouter, gemini, volcengine
+  # 图片服务提供者: openai, minimax, tuzi, modelscope, openrouter, gemini, volcengine
   image_provider: "tuzi"
 
   # API 配置
@@ -35,6 +35,90 @@ image:
 ```
 
 ## 支持的图片服务
+
+### MiniMax
+
+MiniMax 提供 `image-01` 系列图片生成能力，并且是当前唯一支持主体参考（subject reference / 图生图）的 provider。
+
+如果省略 `image_base_url` / `IMAGE_API_BASE`，默认使用全球站 `https://api.minimax.io`；国内站请显式配置 `https://api.minimaxi.com`。
+如果省略 `image_model` / `IMAGE_MODEL`，默认值是 `image-01`；如果省略 `image_size` / `IMAGE_SIZE`，默认值是 `1:1`。
+
+#### 配置示例
+
+```yaml
+api:
+  image_provider: "minimax"
+  image_key: "minimax-..."
+  image_base_url: "https://api.minimax.io"  # 国内站: https://api.minimaxi.com
+  image_model: "image-01"
+  image_size: "1:1"
+```
+
+或使用环境变量：
+
+```bash
+export IMAGE_PROVIDER="minimax"
+export IMAGE_API_KEY="minimax-..."
+export IMAGE_API_BASE="https://api.minimax.io"   # 国内站: https://api.minimaxi.com
+export IMAGE_MODEL="image-01"
+export IMAGE_SIZE="1:1"
+```
+
+#### 区域 endpoint
+
+| 区域 | Base URL |
+|------|----------|
+| 全球站（默认） | `https://api.minimax.io` |
+| 国内站 | `https://api.minimaxi.com` |
+
+请求路径为 `POST /v1/image_generation`，鉴权方式为 `Authorization: Bearer <IMAGE_API_KEY>`。
+
+#### 支持的模型
+
+| 模型 | 说明 | 支持主体参考 |
+|------|------|--------------|
+| `image-01` | MiniMax 图片模型（默认） | 是 |
+| `image-01-live` | MiniMax live 图片模型 | 否 |
+
+#### 支持的尺寸
+
+`image_size` 既可以是宽高比，也可以是 `宽x高` 形式：
+
+| 写法 | 说明 |
+|------|------|
+| `1:1`（默认） | 按宽高比生成，另支持 `16:9`、`4:3`、`3:2`、`2:3`、`3:4`、`9:16`、`21:9` |
+| `1024x768` | 显式像素尺寸，会作为 `width` / `height` 传给 API |
+
+补充说明：
+
+- 使用 `宽x高` 时不再发送 `aspect_ratio`，两者不会同时出现
+- `image_size` 写成无法解析的值（例如 `2K`）会直接返回 `invalid_size`，不会发出请求
+
+#### 主体参考（图生图）
+
+`--subject-reference` 会把人像参考图作为 `subject_reference` 传给 MiniMax，用于在生成结果中保持同一人物形象：
+
+```bash
+md2wechat generate_image "保持同一人物形象的秋日封面" \
+  --subject-reference "https://cdn.example.com/portrait.png"
+```
+
+限制说明：
+
+- 只支持 `minimax` provider，其他 provider 传入该参数会立即返回 `CONFIG_INVALID`
+- 只支持 `image-01`，`image-01-live` 或未知模型会立即返回 `CONFIG_INVALID`
+- 参考图必须是可公开访问的 `http://` 或 `https://` 图片 URL；当前不支持内联 data URL 和本地路径
+- 建议使用单人正脸照片，格式 `JPG` / `JPEG` / `PNG`
+- 参考类型固定为 `character`（人像）
+- 可以和 `--size`、`--model` 组合使用
+- 想确认当前 CLI 是否识别到该能力，执行 `md2wechat providers show minimax --json`，查看 `supports_subject_reference`
+
+#### 官方文档
+
+- https://platform.minimax.io/docs/api-reference/api-overview
+- https://platform.minimaxi.com/docs/api-reference/api-overview
+
+---
 
 ### TuZi
 
@@ -501,7 +585,7 @@ md2wechat convert article.md --preview
 ### Q: 提示 "参数配置有误" 怎么办？
 
 **A:** 请检查：
-1. `image_provider` 是否为 `openai`、`tuzi`、`modelscope`、`openrouter`、`gemini` 或 `volcengine`
+1. `image_provider` 是否为 `openai`、`minimax`、`tuzi`、`modelscope`、`openrouter`、`gemini` 或 `volcengine`
 2. `image_model` 是否在支持的模型列表中
 3. `image_size` 是否在支持的尺寸列表中
 4. **ModelScope 只支持 `WIDTHxHEIGHT`**
@@ -574,3 +658,19 @@ export IMAGE_SIZE="2048x2048"  # TuZi 要求最小 3686400 像素
 | `bad_request` | 参数错误 | 检查模型和尺寸配置 |
 | `network_error` | 网络错误 | 检查网络连接和 API 地址 |
 | `no_image` | 未生成图片 | 检查提示词是否符合内容政策 |
+| `safety_blocked` | 提示词被内容安全策略拦截 | 修改提示词后重试 |
+| `server_error` | 上游服务错误（HTTP 5xx） | 稍后重试 |
+| `invalid_size` | 尺寸既不是宽高比也不是 `宽x高` | 检查 `image_size` / `--size` |
+| `invalid_subject_reference` | 主体参考图不是可公开访问的 http(s) 图片 URL | 上传参考图后传入其公开 URL |
+| `subject_reference_unsupported` | 当前模型不支持主体参考 | 改用 `image-01` |
+
+MiniMax 返回的 `base_resp.status_code` 会映射到上面的错误代码，并在错误信息中保留上游状态码和状态信息：
+
+| `base_resp.status_code` | 错误代码 |
+|-------------------------|----------|
+| `1004` / `2049` | `unauthorized` |
+| `1002` | `rate_limit` |
+| `1008` | `payment_required` |
+| `1026` | `safety_blocked` |
+| `2013` | `bad_request` |
+| 其他非 0 值 | `api_error` |

--- a/docs/IMAGE_PROVISIONERS.md
+++ b/docs/IMAGE_PROVISIONERS.md
@@ -672,5 +672,6 @@ MiniMax 返回的 `base_resp.status_code` 会映射到上面的错误代码，�
 | `1002` | `rate_limit` |
 | `1008` | `payment_required` |
 | `1026` | `safety_blocked` |
+| `1027` | `safety_blocked` |
 | `2013` | `bad_request` |
 | 其他非 0 值 | `api_error` |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -288,7 +288,13 @@ md2wechat generate_image --preset cover-hero --article article.md
 
 # 单次覆盖图片模型
 md2wechat generate_image --preset cover-hero --article article.md --model gemini-3-pro-image-preview
+
+# 用人像参考图保持同一人物形象（仅 minimax provider 的 image-01 支持）
+md2wechat generate_image "保持同一人物形象的秋日封面" \
+  --subject-reference "https://cdn.example.com/portrait.png"
 ```
+
+`--subject-reference` 需要一个可公开访问的 `http(s)` 人像图片 URL，当前不支持内联 data URL 和本地路径。如果当前 provider 或模型不支持该参数，命令会立即返回 `CONFIG_INVALID`，不会发起图片生成请求。可以先用 `md2wechat providers show minimax --json` 确认 `supports_subject_reference`。详见 [图片生成服务配置](IMAGE_PROVISIONERS.md)。
 
 ### 只生成 Agent 图片计划
 
@@ -305,6 +311,7 @@ md2wechat generate_cover --article article.md --plan --json
 ```bash
 md2wechat providers show openrouter --json
 md2wechat providers show volcengine --json
+md2wechat providers show minimax --json
 ```
 
 优先看返回里的 `supported_models`，不要凭记忆写死模型名。

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -258,6 +258,16 @@ func applyImageProviderDefaults(cfg *Config) {
 		if cfg.ImageSize == "" {
 			cfg.ImageSize = "2K"
 		}
+	case "minimax":
+		if cfg.ImageAPIBase == "" {
+			cfg.ImageAPIBase = "https://api.minimax.io"
+		}
+		if cfg.ImageModel == "" {
+			cfg.ImageModel = "image-01"
+		}
+		if cfg.ImageSize == "" {
+			cfg.ImageSize = "1:1"
+		}
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -483,6 +483,56 @@ api:
 	}
 }
 
+func TestLoadWithDefaultsAppliesMiniMaxImageDefaults(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := strings.TrimSpace(`
+api:
+  image_provider: "minimax"
+`)
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadWithDefaults(path)
+	if err != nil {
+		t.Fatalf("LoadWithDefaults() error = %v", err)
+	}
+	if cfg.ImageAPIBase != "https://api.minimax.io" {
+		t.Fatalf("ImageAPIBase = %q", cfg.ImageAPIBase)
+	}
+	if cfg.ImageModel != "image-01" {
+		t.Fatalf("ImageModel = %q", cfg.ImageModel)
+	}
+	if cfg.ImageSize != "1:1" {
+		t.Fatalf("ImageSize = %q", cfg.ImageSize)
+	}
+}
+
+func TestLoadWithDefaultsKeepsMiniMaxChinaEndpointOverride(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := strings.TrimSpace(`
+api:
+  image_provider: "minimax"
+  image_base_url: "https://api.minimaxi.com"
+`)
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadWithDefaults(path)
+	if err != nil {
+		t.Fatalf("LoadWithDefaults() error = %v", err)
+	}
+	if cfg.ImageAPIBase != "https://api.minimaxi.com" {
+		t.Fatalf("ImageAPIBase = %q, want the configured China endpoint", cfg.ImageAPIBase)
+	}
+	if cfg.ImageModel != "image-01" {
+		t.Fatalf("ImageModel = %q", cfg.ImageModel)
+	}
+}
+
 func TestConfigErrorFormatting(t *testing.T) {
 	err := (&ConfigError{
 		Field:   "WechatSecret",

--- a/internal/image/minimax.go
+++ b/internal/image/minimax.go
@@ -1,0 +1,122 @@
+package image
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/geekjourneyx/md2wechat-skill/internal/config"
+)
+
+// MiniMaxProvider generates images with optional portrait references.
+type MiniMaxProvider struct {
+	apiKey  string
+	baseURL string
+	model   string
+	size    string
+	client  *http.Client
+}
+
+func NewMiniMaxProvider(cfg *config.Config) (*MiniMaxProvider, error) {
+	if err := validateMiniMaxConfig(cfg); err != nil {
+		return nil, err
+	}
+	baseURL := strings.TrimRight(strings.TrimSpace(cfg.ImageAPIBase), "/")
+	if baseURL == "" {
+		baseURL = "https://api.minimax.io"
+	}
+	model := strings.TrimSpace(cfg.ImageModel)
+	if model == "" {
+		model = "image-01"
+	}
+	size := strings.TrimSpace(cfg.ImageSize)
+	if size == "" {
+		size = "1:1"
+	}
+	return &MiniMaxProvider{
+		apiKey: cfg.ImageAPIKey, baseURL: baseURL, model: model, size: size,
+		client: &http.Client{Timeout: 60 * time.Second},
+	}, nil
+}
+
+func (p *MiniMaxProvider) Name() string { return "MiniMax" }
+
+func (p *MiniMaxProvider) Generate(ctx context.Context, prompt string) (*GenerateResult, error) {
+	return p.generate(ctx, prompt, "")
+}
+
+func (p *MiniMaxProvider) GenerateWithSubject(ctx context.Context, prompt, subjectReference string) (*GenerateResult, error) {
+	if strings.TrimSpace(subjectReference) == "" {
+		return nil, &GenerateError{Provider: p.Name(), Code: "invalid_subject_reference", Message: "subject reference is required"}
+	}
+	return p.generate(ctx, prompt, subjectReference)
+}
+
+func (p *MiniMaxProvider) generate(ctx context.Context, prompt, subjectReference string) (*GenerateResult, error) {
+	payload := map[string]any{
+		"model": p.model, "prompt": prompt,
+		"response_format": "url", "n": 1,
+	}
+	if dimensions := strings.Split(p.size, "x"); len(dimensions) == 2 {
+		width, widthErr := strconv.Atoi(dimensions[0])
+		height, heightErr := strconv.Atoi(dimensions[1])
+		if widthErr != nil || heightErr != nil {
+			return nil, &GenerateError{Provider: p.Name(), Code: "invalid_size", Message: "image size must be an aspect ratio or WIDTHxHEIGHT"}
+		}
+		payload["width"] = width
+		payload["height"] = height
+	} else {
+		payload["aspect_ratio"] = p.size
+	}
+	if subjectReference != "" {
+		payload["subject_reference"] = []map[string]string{{"type": "character", "image_file": subjectReference}}
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, &GenerateError{Provider: p.Name(), Code: "marshal_error", Message: "request encoding failed", Original: err}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/v1/image_generation", bytes.NewReader(body))
+	if err != nil {
+		return nil, &GenerateError{Provider: p.Name(), Code: "request_error", Message: "request creation failed", Original: err}
+	}
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, &GenerateError{Provider: p.Name(), Code: "network_error", Message: "image request failed", Original: err}
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode != http.StatusOK {
+		return nil, &GenerateError{Provider: p.Name(), Code: "http_error", Message: fmt.Sprintf("image request returned HTTP %d", resp.StatusCode)}
+	}
+	var response struct {
+		Data struct {
+			ImageURLs []string `json:"image_urls"`
+		} `json:"data"`
+		Metadata struct {
+			SuccessCount int `json:"success_count"`
+			FailedCount  int `json:"failed_count"`
+		} `json:"metadata"`
+		BaseResp struct {
+			StatusCode int    `json:"status_code"`
+			StatusMsg  string `json:"status_msg"`
+		} `json:"base_resp"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, &GenerateError{Provider: p.Name(), Code: "decode_error", Message: "response decoding failed", Original: err}
+	}
+	if response.BaseResp.StatusCode != 0 {
+		return nil, &GenerateError{Provider: p.Name(), Code: "api_error", Message: response.BaseResp.StatusMsg}
+	}
+	if response.Metadata.SuccessCount < 1 || len(response.Data.ImageURLs) == 0 || strings.TrimSpace(response.Data.ImageURLs[0]) == "" {
+		return nil, &GenerateError{Provider: p.Name(), Code: "no_image", Message: "response did not include a generated image"}
+	}
+	return &GenerateResult{URL: response.Data.ImageURLs[0], Model: p.model, Size: p.size}, nil
+}

--- a/internal/image/minimax.go
+++ b/internal/image/minimax.go
@@ -5,12 +5,22 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/geekjourneyx/md2wechat-skill/internal/config"
+)
+
+const (
+	miniMaxDefaultBaseURL = "https://api.minimax.io"
+	miniMaxDefaultModel   = "image-01"
+	miniMaxDefaultSize    = "1:1"
+	miniMaxImagePath      = "/v1/image_generation"
+	miniMaxSubjectType    = "character"
+	miniMaxErrorBodyLimit = 8 << 10
 )
 
 // MiniMaxProvider generates images with optional portrait references.
@@ -28,15 +38,15 @@ func NewMiniMaxProvider(cfg *config.Config) (*MiniMaxProvider, error) {
 	}
 	baseURL := strings.TrimRight(strings.TrimSpace(cfg.ImageAPIBase), "/")
 	if baseURL == "" {
-		baseURL = "https://api.minimax.io"
+		baseURL = miniMaxDefaultBaseURL
 	}
 	model := strings.TrimSpace(cfg.ImageModel)
 	if model == "" {
-		model = "image-01"
+		model = miniMaxDefaultModel
 	}
 	size := strings.TrimSpace(cfg.ImageSize)
 	if size == "" {
-		size = "1:1"
+		size = miniMaxDefaultSize
 	}
 	return &MiniMaxProvider{
 		apiKey: cfg.ImageAPIKey, baseURL: baseURL, model: model, size: size,
@@ -50,11 +60,39 @@ func (p *MiniMaxProvider) Generate(ctx context.Context, prompt string) (*Generat
 	return p.generate(ctx, prompt, "")
 }
 
+// GenerateWithSubject generates an image guided by a portrait reference. The
+// reference must be a public HTTP(S) image URL and the configured model must
+// accept subject references.
 func (p *MiniMaxProvider) GenerateWithSubject(ctx context.Context, prompt, subjectReference string) (*GenerateResult, error) {
-	if strings.TrimSpace(subjectReference) == "" {
-		return nil, &GenerateError{Provider: p.Name(), Code: "invalid_subject_reference", Message: "subject reference is required"}
+	reference, err := p.validateSubjectReference(subjectReference)
+	if err != nil {
+		return nil, err
 	}
-	return p.generate(ctx, prompt, subjectReference)
+	if !ModelSupportsSubjectReference("minimax", p.model) {
+		return nil, &GenerateError{
+			Provider: p.Name(),
+			Code:     "subject_reference_unsupported",
+			Message:  fmt.Sprintf("model %s does not support subject references", p.model),
+			Hint:     SubjectReferenceModelsHint("minimax"),
+		}
+	}
+	return p.generate(ctx, prompt, reference)
+}
+
+// validateSubjectReference keeps the supported contract limited to public
+// HTTP(S) image URLs so unusable values fail before the request is sent.
+func (p *MiniMaxProvider) validateSubjectReference(subjectReference string) (string, error) {
+	reference := strings.TrimSpace(subjectReference)
+	if err := ValidateSubjectReferenceURL(reference); err != nil {
+		return "", &GenerateError{
+			Provider: p.Name(),
+			Code:     "invalid_subject_reference",
+			Message:  err.Error(),
+			Hint:     "Pass a public HTTP(S) URL of a single front-facing portrait in JPG, JPEG, or PNG format",
+			Original: err,
+		}
+	}
+	return reference, nil
 }
 
 func (p *MiniMaxProvider) generate(ctx context.Context, prompt, subjectReference string) (*GenerateResult, error) {
@@ -74,13 +112,13 @@ func (p *MiniMaxProvider) generate(ctx context.Context, prompt, subjectReference
 		payload["aspect_ratio"] = p.size
 	}
 	if subjectReference != "" {
-		payload["subject_reference"] = []map[string]string{{"type": "character", "image_file": subjectReference}}
+		payload["subject_reference"] = []map[string]string{{"type": miniMaxSubjectType, "image_file": subjectReference}}
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return nil, &GenerateError{Provider: p.Name(), Code: "marshal_error", Message: "request encoding failed", Original: err}
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/v1/image_generation", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+miniMaxImagePath, bytes.NewReader(body))
 	if err != nil {
 		return nil, &GenerateError{Provider: p.Name(), Code: "request_error", Message: "request creation failed", Original: err}
 	}
@@ -94,29 +132,235 @@ func (p *MiniMaxProvider) generate(ctx context.Context, prompt, subjectReference
 		_ = resp.Body.Close()
 	}()
 	if resp.StatusCode != http.StatusOK {
-		return nil, &GenerateError{Provider: p.Name(), Code: "http_error", Message: fmt.Sprintf("image request returned HTTP %d", resp.StatusCode)}
+		return nil, p.handleErrorResponse(resp)
 	}
 	var response struct {
 		Data struct {
 			ImageURLs []string `json:"image_urls"`
 		} `json:"data"`
 		Metadata struct {
-			SuccessCount int `json:"success_count"`
-			FailedCount  int `json:"failed_count"`
+			SuccessCount *flexibleInt `json:"success_count"`
+			FailedCount  *flexibleInt `json:"failed_count"`
 		} `json:"metadata"`
 		BaseResp struct {
-			StatusCode int    `json:"status_code"`
-			StatusMsg  string `json:"status_msg"`
+			StatusCode flexibleInt `json:"status_code"`
+			StatusMsg  string      `json:"status_msg"`
 		} `json:"base_resp"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
 		return nil, &GenerateError{Provider: p.Name(), Code: "decode_error", Message: "response decoding failed", Original: err}
 	}
-	if response.BaseResp.StatusCode != 0 {
-		return nil, &GenerateError{Provider: p.Name(), Code: "api_error", Message: response.BaseResp.StatusMsg}
+	if code := response.BaseResp.StatusCode.Int(); code != 0 {
+		return nil, p.apiError(code, response.BaseResp.StatusMsg, nil)
 	}
-	if response.Metadata.SuccessCount < 1 || len(response.Data.ImageURLs) == 0 || strings.TrimSpace(response.Data.ImageURLs[0]) == "" {
+	if count := response.Metadata.SuccessCount; count != nil && count.Int() < 1 {
+		return nil, &GenerateError{
+			Provider: p.Name(),
+			Code:     "no_image",
+			Message:  fmt.Sprintf("provider reported %d successful and %d failed images", count.Int(), response.Metadata.FailedCount.Int()),
+			Hint:     "The prompt may violate the content policy; try rewording it",
+		}
+	}
+	if len(response.Data.ImageURLs) == 0 || strings.TrimSpace(response.Data.ImageURLs[0]) == "" {
 		return nil, &GenerateError{Provider: p.Name(), Code: "no_image", Message: "response did not include a generated image"}
 	}
 	return &GenerateResult{URL: response.Data.ImageURLs[0], Model: p.model, Size: p.size}, nil
+}
+
+// handleErrorResponse preserves the upstream HTTP status and MiniMax base_resp
+// details instead of discarding the response body.
+func (p *MiniMaxProvider) handleErrorResponse(resp *http.Response) error {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, miniMaxErrorBodyLimit))
+	snippet := strings.TrimSpace(string(body))
+
+	var payload struct {
+		BaseResp struct {
+			StatusCode flexibleInt `json:"status_code"`
+			StatusMsg  string      `json:"status_msg"`
+		} `json:"base_resp"`
+	}
+	_ = json.Unmarshal(body, &payload)
+
+	original := fmt.Errorf("status %d: %s", resp.StatusCode, snippet)
+	if code := payload.BaseResp.StatusCode.Int(); code != 0 {
+		return p.apiError(code, payload.BaseResp.StatusMsg, original)
+	}
+
+	message := strings.TrimSpace(payload.BaseResp.StatusMsg)
+	if message == "" {
+		message = snippet
+	}
+	if message == "" {
+		message = fmt.Sprintf("image request returned HTTP %d", resp.StatusCode)
+	}
+
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+		return &GenerateError{
+			Provider: p.Name(),
+			Code:     "unauthorized",
+			Message:  fmt.Sprintf("MiniMax rejected the API key: %s", message),
+			Hint:     "Check api.image_key in the config file or the IMAGE_API_KEY environment variable",
+			Original: original,
+		}
+	case resp.StatusCode == http.StatusPaymentRequired:
+		return &GenerateError{
+			Provider: p.Name(),
+			Code:     "payment_required",
+			Message:  fmt.Sprintf("MiniMax account balance is insufficient: %s", message),
+			Hint:     "Top up the MiniMax account and retry",
+			Original: original,
+		}
+	case resp.StatusCode == http.StatusTooManyRequests:
+		return &GenerateError{
+			Provider: p.Name(),
+			Code:     "rate_limit",
+			Message:  fmt.Sprintf("MiniMax rate limit triggered: %s", message),
+			Hint:     "Wait a moment and retry",
+			Original: original,
+		}
+	case resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusUnprocessableEntity:
+		return &GenerateError{
+			Provider: p.Name(),
+			Code:     "bad_request",
+			Message:  fmt.Sprintf("MiniMax rejected the request parameters: %s", message),
+			Hint:     "Check the model name, aspect ratio or WIDTHxHEIGHT size, and subject reference URL",
+			Original: original,
+		}
+	case resp.StatusCode >= http.StatusInternalServerError:
+		return &GenerateError{
+			Provider: p.Name(),
+			Code:     "server_error",
+			Message:  fmt.Sprintf("MiniMax service error: %s", message),
+			Hint:     "The upstream service is unavailable; retry later",
+			Original: original,
+		}
+	default:
+		return &GenerateError{
+			Provider: p.Name(),
+			Code:     "http_error",
+			Message:  fmt.Sprintf("image request returned HTTP %d: %s", resp.StatusCode, message),
+			Original: original,
+		}
+	}
+}
+
+// apiError maps documented MiniMax base_resp status codes to actionable errors
+// while keeping the upstream code and message visible.
+func (p *MiniMaxProvider) apiError(code int, statusMsg string, original error) error {
+	message := strings.TrimSpace(statusMsg)
+	withUpstream := func(text string) string {
+		if message == "" {
+			return fmt.Sprintf("%s (base_resp.status_code=%d)", text, code)
+		}
+		return fmt.Sprintf("%s (base_resp.status_code=%d: %s)", text, code, message)
+	}
+
+	switch code {
+	case 1004:
+		return &GenerateError{
+			Provider: p.Name(),
+			Code:     "unauthorized",
+			Message:  withUpstream("MiniMax account authentication failed"),
+			Hint:     "Check api.image_key in the config file or the IMAGE_API_KEY environment variable",
+			Original: original,
+		}
+	case 2049:
+		return &GenerateError{
+			Provider: p.Name(),
+			Code:     "unauthorized",
+			Message:  withUpstream("MiniMax API key is invalid"),
+			Hint:     "Create a new API key in the MiniMax console and update api.image_key",
+			Original: original,
+		}
+	case 1002:
+		return &GenerateError{
+			Provider: p.Name(),
+			Code:     "rate_limit",
+			Message:  withUpstream("MiniMax rate limit triggered"),
+			Hint:     "Wait a moment and retry",
+			Original: original,
+		}
+	case 1008:
+		return &GenerateError{
+			Provider: p.Name(),
+			Code:     "payment_required",
+			Message:  withUpstream("MiniMax account balance is insufficient"),
+			Hint:     "Top up the MiniMax account and retry",
+			Original: original,
+		}
+	case 1026:
+		return &GenerateError{
+			Provider: p.Name(),
+			Code:     "safety_blocked",
+			Message:  withUpstream("MiniMax flagged sensitive content in the prompt"),
+			Hint:     "Reword the prompt to comply with the content policy",
+			Original: original,
+		}
+	case 2013:
+		return &GenerateError{
+			Provider: p.Name(),
+			Code:     "bad_request",
+			Message:  withUpstream("MiniMax rejected the request parameters"),
+			Hint:     "Check the model name, aspect ratio or WIDTHxHEIGHT size, and subject reference URL",
+			Original: original,
+		}
+	default:
+		return &GenerateError{
+			Provider: p.Name(),
+			Code:     "api_error",
+			Message:  withUpstream("MiniMax image generation failed"),
+			Original: original,
+		}
+	}
+}
+
+// flexibleInt decodes integers that the MiniMax API may encode either as JSON
+// numbers or as quoted strings, which the official response examples do.
+type flexibleInt int
+
+func (v *flexibleInt) Int() int {
+	if v == nil {
+		return 0
+	}
+	return int(*v)
+}
+
+func (v *flexibleInt) UnmarshalJSON(data []byte) error {
+	text := strings.TrimSpace(string(data))
+	if text == "" || text == "null" {
+		*v = 0
+		return nil
+	}
+	if strings.HasPrefix(text, `"`) {
+		var quoted string
+		if err := json.Unmarshal(data, &quoted); err != nil {
+			return err
+		}
+		quoted = strings.TrimSpace(quoted)
+		if quoted == "" {
+			*v = 0
+			return nil
+		}
+		parsed, err := strconv.Atoi(quoted)
+		if err != nil {
+			return fmt.Errorf("decode %q as integer: %w", quoted, err)
+		}
+		*v = flexibleInt(parsed)
+		return nil
+	}
+	var number json.Number
+	if err := json.Unmarshal(data, &number); err != nil {
+		return err
+	}
+	parsed, err := number.Int64()
+	if err != nil {
+		asFloat, floatErr := number.Float64()
+		if floatErr != nil {
+			return err
+		}
+		parsed = int64(asFloat)
+	}
+	*v = flexibleInt(parsed)
+	return nil
 }

--- a/internal/image/minimax.go
+++ b/internal/image/minimax.go
@@ -297,6 +297,14 @@ func (p *MiniMaxProvider) apiError(code int, statusMsg string, original error) e
 			Hint:     "Reword the prompt to comply with the content policy",
 			Original: original,
 		}
+	case 1027:
+		return &GenerateError{
+			Provider: p.Name(),
+			Code:     "safety_blocked",
+			Message:  withUpstream("MiniMax flagged sensitive content in the generated output"),
+			Hint:     "Revise the prompt or requested subject to comply with the content policy",
+			Original: original,
+		}
 	case 2013:
 		return &GenerateError{
 			Provider: p.Name(),

--- a/internal/image/minimax_test.go
+++ b/internal/image/minimax_test.go
@@ -3,26 +3,54 @@ package image
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/geekjourneyx/md2wechat-skill/internal/config"
 )
 
-func TestMiniMaxGenerateWithSubject(t *testing.T) {
-	provider, err := NewMiniMaxProvider(&config.Config{
-		ImageAPIKey: "image-key", ImageAPIBase: "https://api.minimax.test",
-		ImageModel: "image-01", ImageSize: "16:9",
-	})
+// officialMiniMaxResponse mirrors the official MiniMax image generation example,
+// which encodes metadata.success_count and failed_count as JSON strings.
+const officialMiniMaxResponse = `{"data":{"image_urls":["https://cdn.example/result.png"]},"metadata":{"success_count":"1","failed_count":"0"},"base_resp":{"status_code":0,"status_msg":"success"}}`
+
+func newTestMiniMaxProvider(t *testing.T, cfg *config.Config, fn roundTripFunc) *MiniMaxProvider {
+	t.Helper()
+	provider, err := NewMiniMaxProvider(cfg)
 	if err != nil {
 		t.Fatalf("NewMiniMaxProvider() error = %v", err)
 	}
-	provider.client = &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+	provider.client = newMockHTTPClient(fn)
+	return provider
+}
+
+func miniMaxGenerateError(t *testing.T, err error) *GenerateError {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	var genErr *GenerateError
+	if !errors.As(err, &genErr) {
+		t.Fatalf("error %v is not a *GenerateError", err)
+	}
+	return genErr
+}
+
+func TestMiniMaxGenerateWithSubject(t *testing.T) {
+	provider := newTestMiniMaxProvider(t, &config.Config{
+		ImageAPIKey: "image-key", ImageAPIBase: "https://api.minimax.test",
+		ImageModel: "image-01", ImageSize: "16:9",
+	}, func(request *http.Request) (*http.Response, error) {
 		if request.Method != http.MethodPost || request.URL.Path != "/v1/image_generation" {
 			t.Fatalf("unexpected request: %s %s", request.Method, request.URL.Path)
 		}
 		if got := request.Header.Get("Authorization"); got != "Bearer image-key" {
 			t.Fatalf("Authorization = %q", got)
+		}
+		if got := request.Header.Get("Content-Type"); got != "application/json" {
+			t.Fatalf("Content-Type = %q", got)
 		}
 		var payload map[string]any
 		if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
@@ -39,8 +67,11 @@ func TestMiniMaxGenerateWithSubject(t *testing.T) {
 		if payload["aspect_ratio"] != "16:9" || payload["model"] != "image-01" {
 			t.Fatalf("payload = %#v", payload)
 		}
-		return jsonResponse(http.StatusOK, `{"data":{"image_urls":["https://cdn.example/result.png"]},"metadata":{"success_count":1,"failed_count":0},"base_resp":{"status_code":0,"status_msg":"success"}}`), nil
-	})}
+		if payload["response_format"] != "url" {
+			t.Fatalf("response_format = %#v", payload["response_format"])
+		}
+		return jsonResponse(http.StatusOK, officialMiniMaxResponse), nil
+	})
 
 	result, err := provider.GenerateWithSubject(context.Background(), "Keep the character", "https://cdn.example/portrait.png")
 	if err != nil {
@@ -48,6 +79,138 @@ func TestMiniMaxGenerateWithSubject(t *testing.T) {
 	}
 	if result.URL != "https://cdn.example/result.png" || result.Model != "image-01" {
 		t.Fatalf("result = %#v", result)
+	}
+	if result.Size != "16:9" {
+		t.Fatalf("result size = %q", result.Size)
+	}
+}
+
+// TestMiniMaxAcceptsNumericAndStringMetadataCounts guards the official response
+// shape, which quotes the counts, as well as the schema shape, which does not.
+func TestMiniMaxAcceptsNumericAndStringMetadataCounts(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{name: "official_string_counts", body: officialMiniMaxResponse},
+		{name: "numeric_counts", body: `{"data":{"image_urls":["https://cdn.example/result.png"]},"metadata":{"success_count":1,"failed_count":0},"base_resp":{"status_code":0}}`},
+		{name: "string_status_code", body: `{"data":{"image_urls":["https://cdn.example/result.png"]},"metadata":{"success_count":"2","failed_count":"0"},"base_resp":{"status_code":"0"}}`},
+		{name: "missing_metadata", body: `{"data":{"image_urls":["https://cdn.example/result.png"]},"base_resp":{"status_code":0}}`},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			provider := newTestMiniMaxProvider(t, &config.Config{ImageAPIKey: "image-key"}, func(*http.Request) (*http.Response, error) {
+				return jsonResponse(http.StatusOK, testCase.body), nil
+			})
+			result, err := provider.Generate(context.Background(), "prompt")
+			if err != nil {
+				t.Fatalf("Generate() error = %v", err)
+			}
+			if result.URL != "https://cdn.example/result.png" {
+				t.Fatalf("result = %#v", result)
+			}
+		})
+	}
+}
+
+func TestMiniMaxAppliesDocumentedDefaults(t *testing.T) {
+	provider := newTestMiniMaxProvider(t, &config.Config{ImageAPIKey: "image-key"}, func(request *http.Request) (*http.Response, error) {
+		if request.URL.Host != "api.minimax.io" {
+			t.Fatalf("host = %q, want the global endpoint", request.URL.Host)
+		}
+		var payload map[string]any
+		if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+			t.Fatal(err)
+		}
+		if payload["model"] != "image-01" || payload["aspect_ratio"] != "1:1" {
+			t.Fatalf("payload = %#v", payload)
+		}
+		return jsonResponse(http.StatusOK, officialMiniMaxResponse), nil
+	})
+	if _, err := provider.Generate(context.Background(), "prompt"); err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+}
+
+func TestMiniMaxUsesConfiguredChinaEndpoint(t *testing.T) {
+	provider := newTestMiniMaxProvider(t, &config.Config{
+		ImageAPIKey: "image-key", ImageAPIBase: "https://api.minimaxi.com/",
+	}, func(request *http.Request) (*http.Response, error) {
+		if request.URL.String() != "https://api.minimaxi.com/v1/image_generation" {
+			t.Fatalf("request URL = %q", request.URL.String())
+		}
+		return jsonResponse(http.StatusOK, officialMiniMaxResponse), nil
+	})
+	if _, err := provider.Generate(context.Background(), "prompt"); err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+}
+
+func TestMiniMaxSizeOverrides(t *testing.T) {
+	cases := []struct {
+		name        string
+		size        string
+		wantWidth   float64
+		wantHeight  float64
+		wantAspect  string
+		wantErrCode string
+	}{
+		{name: "aspect_ratio", size: "3:4", wantAspect: "3:4"},
+		{name: "explicit_dimensions", size: "1024x768", wantWidth: 1024, wantHeight: 768},
+		{name: "invalid_dimensions", size: "widthxheight", wantErrCode: "invalid_size"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			provider := newTestMiniMaxProvider(t, &config.Config{
+				ImageAPIKey: "image-key", ImageSize: testCase.size,
+			}, func(request *http.Request) (*http.Response, error) {
+				var payload map[string]any
+				if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+					t.Fatal(err)
+				}
+				if testCase.wantAspect != "" && payload["aspect_ratio"] != testCase.wantAspect {
+					t.Fatalf("aspect_ratio = %#v", payload["aspect_ratio"])
+				}
+				if testCase.wantWidth != 0 {
+					if payload["width"] != testCase.wantWidth || payload["height"] != testCase.wantHeight {
+						t.Fatalf("width/height = %#v/%#v", payload["width"], payload["height"])
+					}
+					if _, ok := payload["aspect_ratio"]; ok {
+						t.Fatal("aspect_ratio must be omitted when explicit dimensions are used")
+					}
+				}
+				return jsonResponse(http.StatusOK, officialMiniMaxResponse), nil
+			})
+
+			_, err := provider.Generate(context.Background(), "prompt")
+			if testCase.wantErrCode == "" {
+				if err != nil {
+					t.Fatalf("Generate() error = %v", err)
+				}
+				return
+			}
+			if got := miniMaxGenerateError(t, err).Code; got != testCase.wantErrCode {
+				t.Fatalf("error code = %q, want %q", got, testCase.wantErrCode)
+			}
+		})
+	}
+}
+
+func TestMiniMaxModelOverrideIsForwarded(t *testing.T) {
+	provider := newTestMiniMaxProvider(t, &config.Config{
+		ImageAPIKey: "image-key", ImageModel: "image-01-live",
+	}, func(request *http.Request) (*http.Response, error) {
+		var payload map[string]any
+		if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+			t.Fatal(err)
+		}
+		if payload["model"] != "image-01-live" {
+			t.Fatalf("model = %#v", payload["model"])
+		}
+		return jsonResponse(http.StatusOK, officialMiniMaxResponse), nil
+	})
+	if _, err := provider.Generate(context.Background(), "prompt"); err != nil {
+		t.Fatalf("Generate() error = %v", err)
 	}
 }
 
@@ -58,5 +221,231 @@ func TestMiniMaxGenerateRejectsMissingSubject(t *testing.T) {
 	}
 	if _, err := provider.GenerateWithSubject(context.Background(), "prompt", " "); err == nil {
 		t.Fatal("expected missing subject reference error")
+	}
+}
+
+// TestMiniMaxRejectsUnsupportedSubjectReferenceValues keeps the supported
+// contract limited to validated public HTTP(S) URLs.
+func TestMiniMaxRejectsUnsupportedSubjectReferenceValues(t *testing.T) {
+	cases := []struct {
+		name      string
+		reference string
+	}{
+		{name: "empty", reference: "   "},
+		{name: "data_url", reference: "data:image/jpeg;base64,QUJD"},
+		{name: "local_path", reference: "/tmp/portrait.png"},
+		{name: "relative_path", reference: "portrait.png"},
+		{name: "unsupported_scheme", reference: "ftp://cdn.example/portrait.png"},
+		{name: "missing_host", reference: "https://"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			provider := newTestMiniMaxProvider(t, &config.Config{ImageAPIKey: "image-key"}, func(*http.Request) (*http.Response, error) {
+				t.Fatal("provider must not send a request for an invalid subject reference")
+				return nil, nil
+			})
+			_, err := provider.GenerateWithSubject(context.Background(), "prompt", testCase.reference)
+			if got := miniMaxGenerateError(t, err).Code; got != "invalid_subject_reference" {
+				t.Fatalf("error code = %q, want invalid_subject_reference", got)
+			}
+		})
+	}
+}
+
+func TestMiniMaxRejectsSubjectReferenceForUnsupportedModel(t *testing.T) {
+	provider := newTestMiniMaxProvider(t, &config.Config{
+		ImageAPIKey: "image-key", ImageModel: "image-01-live",
+	}, func(*http.Request) (*http.Response, error) {
+		t.Fatal("provider must not send a request for an unsupported model")
+		return nil, nil
+	})
+
+	_, err := provider.GenerateWithSubject(context.Background(), "prompt", "https://cdn.example/portrait.png")
+	genErr := miniMaxGenerateError(t, err)
+	if genErr.Code != "subject_reference_unsupported" {
+		t.Fatalf("error code = %q", genErr.Code)
+	}
+	if !strings.Contains(genErr.Message, "image-01-live") {
+		t.Fatalf("error message = %q", genErr.Message)
+	}
+	if !strings.Contains(genErr.Hint, "image-01") {
+		t.Fatalf("error hint = %q", genErr.Hint)
+	}
+}
+
+// TestMiniMaxMapsAPIStatusCodes covers the documented base_resp status codes
+// returned alongside HTTP 200.
+func TestMiniMaxMapsAPIStatusCodes(t *testing.T) {
+	cases := []struct {
+		statusCode int
+		wantCode   string
+	}{
+		{statusCode: 1004, wantCode: "unauthorized"},
+		{statusCode: 2049, wantCode: "unauthorized"},
+		{statusCode: 1002, wantCode: "rate_limit"},
+		{statusCode: 1008, wantCode: "payment_required"},
+		{statusCode: 1026, wantCode: "safety_blocked"},
+		{statusCode: 2013, wantCode: "bad_request"},
+		{statusCode: 1039, wantCode: "api_error"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.wantCode+"_"+strconv.Itoa(testCase.statusCode), func(t *testing.T) {
+			body := `{"base_resp":{"status_code":` + strconv.Itoa(testCase.statusCode) + `,"status_msg":"upstream detail"}}`
+			provider := newTestMiniMaxProvider(t, &config.Config{ImageAPIKey: "image-key"}, func(*http.Request) (*http.Response, error) {
+				return jsonResponse(http.StatusOK, body), nil
+			})
+			_, err := provider.Generate(context.Background(), "prompt")
+			genErr := miniMaxGenerateError(t, err)
+			if genErr.Code != testCase.wantCode {
+				t.Fatalf("error code = %q, want %q", genErr.Code, testCase.wantCode)
+			}
+			if !strings.Contains(genErr.Message, "upstream detail") {
+				t.Fatalf("error message %q must preserve the upstream status message", genErr.Message)
+			}
+			if !strings.Contains(genErr.Message, strconv.Itoa(testCase.statusCode)) {
+				t.Fatalf("error message %q must preserve the upstream status code", genErr.Message)
+			}
+		})
+	}
+}
+
+// TestMiniMaxMapsHTTPErrorStatuses covers non-200 responses, whose body was
+// previously discarded.
+func TestMiniMaxMapsHTTPErrorStatuses(t *testing.T) {
+	cases := []struct {
+		httpStatus int
+		wantCode   string
+	}{
+		{httpStatus: http.StatusUnauthorized, wantCode: "unauthorized"},
+		{httpStatus: http.StatusForbidden, wantCode: "unauthorized"},
+		{httpStatus: http.StatusPaymentRequired, wantCode: "payment_required"},
+		{httpStatus: http.StatusTooManyRequests, wantCode: "rate_limit"},
+		{httpStatus: http.StatusBadRequest, wantCode: "bad_request"},
+		{httpStatus: http.StatusUnprocessableEntity, wantCode: "bad_request"},
+		{httpStatus: http.StatusInternalServerError, wantCode: "server_error"},
+		{httpStatus: http.StatusTeapot, wantCode: "http_error"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.wantCode+"_"+strconv.Itoa(testCase.httpStatus), func(t *testing.T) {
+			provider := newTestMiniMaxProvider(t, &config.Config{ImageAPIKey: "image-key"}, func(*http.Request) (*http.Response, error) {
+				return jsonResponse(testCase.httpStatus, `{"detail":"upstream body"}`), nil
+			})
+			_, err := provider.Generate(context.Background(), "prompt")
+			genErr := miniMaxGenerateError(t, err)
+			if genErr.Code != testCase.wantCode {
+				t.Fatalf("error code = %q, want %q", genErr.Code, testCase.wantCode)
+			}
+			if genErr.Original == nil || !strings.Contains(genErr.Original.Error(), "upstream body") {
+				t.Fatalf("original error must preserve the response body, got %v", genErr.Original)
+			}
+		})
+	}
+}
+
+// TestMiniMaxHTTPErrorPrefersBaseResp keeps MiniMax error details even when the
+// transport status is not 200.
+func TestMiniMaxHTTPErrorPrefersBaseResp(t *testing.T) {
+	provider := newTestMiniMaxProvider(t, &config.Config{ImageAPIKey: "image-key"}, func(*http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusBadRequest, `{"base_resp":{"status_code":1008,"status_msg":"insufficient balance"}}`), nil
+	})
+	_, err := provider.Generate(context.Background(), "prompt")
+	genErr := miniMaxGenerateError(t, err)
+	if genErr.Code != "payment_required" {
+		t.Fatalf("error code = %q, want payment_required", genErr.Code)
+	}
+	if !strings.Contains(genErr.Message, "insufficient balance") {
+		t.Fatalf("error message = %q", genErr.Message)
+	}
+}
+
+func TestMiniMaxRejectsUnusableResponses(t *testing.T) {
+	cases := []struct {
+		name     string
+		body     string
+		wantCode string
+	}{
+		{name: "malformed_json", body: `{"data":`, wantCode: "decode_error"},
+		{name: "empty_body", body: ``, wantCode: "decode_error"},
+		{name: "empty_object", body: `{}`, wantCode: "no_image"},
+		{name: "no_image_urls", body: `{"data":{"image_urls":[]},"metadata":{"success_count":"1"},"base_resp":{"status_code":0}}`, wantCode: "no_image"},
+		{name: "blank_image_url", body: `{"data":{"image_urls":["  "]},"metadata":{"success_count":"1"},"base_resp":{"status_code":0}}`, wantCode: "no_image"},
+		{name: "zero_success_count", body: `{"data":{"image_urls":["https://cdn.example/result.png"]},"metadata":{"success_count":"0","failed_count":"1"},"base_resp":{"status_code":0}}`, wantCode: "no_image"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			provider := newTestMiniMaxProvider(t, &config.Config{ImageAPIKey: "image-key"}, func(*http.Request) (*http.Response, error) {
+				return jsonResponse(http.StatusOK, testCase.body), nil
+			})
+			_, err := provider.Generate(context.Background(), "prompt")
+			if got := miniMaxGenerateError(t, err).Code; got != testCase.wantCode {
+				t.Fatalf("error code = %q, want %q", got, testCase.wantCode)
+			}
+		})
+	}
+}
+
+func TestNewMiniMaxProviderRequiresAPIKey(t *testing.T) {
+	if _, err := NewMiniMaxProvider(&config.Config{}); err == nil {
+		t.Fatal("expected a missing API key error")
+	}
+}
+
+func TestNewProviderResolvesMiniMax(t *testing.T) {
+	provider, err := NewProvider(&config.Config{ImageProvider: "minimax", ImageAPIKey: "image-key"})
+	if err != nil {
+		t.Fatalf("NewProvider() error = %v", err)
+	}
+	if provider.Name() != "MiniMax" {
+		t.Fatalf("provider name = %q", provider.Name())
+	}
+	if _, ok := provider.(SubjectReferenceProvider); !ok {
+		t.Fatal("MiniMax provider must implement SubjectReferenceProvider")
+	}
+}
+
+func TestSubjectReferenceCapabilityMetadata(t *testing.T) {
+	if !ProviderSupportsSubjectReference("minimax") {
+		t.Fatal("minimax must advertise subject reference support")
+	}
+	if ProviderSupportsSubjectReference("openai") {
+		t.Fatal("openai must not advertise subject reference support")
+	}
+	if ProviderSupportsSubjectReference("does-not-exist") {
+		t.Fatal("unknown providers must not advertise subject reference support")
+	}
+	if !ModelSupportsSubjectReference("minimax", "image-01") {
+		t.Fatal("image-01 must support subject references")
+	}
+	if !ModelSupportsSubjectReference("minimax", "") {
+		t.Fatal("an empty model must resolve to the default model")
+	}
+	if ModelSupportsSubjectReference("minimax", "image-01-live") {
+		t.Fatal("image-01-live must not support subject references")
+	}
+	if ModelSupportsSubjectReference("minimax", "unknown-model") {
+		t.Fatal("unknown models must not support subject references")
+	}
+	if ModelSupportsSubjectReference("openai", "gpt-image-2") {
+		t.Fatal("openai models must not support subject references")
+	}
+	if got := SubjectReferenceModelNames("minimax"); len(got) != 1 || got[0] != "image-01" {
+		t.Fatalf("SubjectReferenceModelNames() = %#v", got)
+	}
+	if got := SubjectReferenceProviderNames(); len(got) != 1 || got[0] != "minimax" {
+		t.Fatalf("SubjectReferenceProviderNames() = %#v", got)
+	}
+}
+
+func TestUnknownProviderHintListsMiniMax(t *testing.T) {
+	_, err := NewProvider(&config.Config{ImageProvider: "nope", ImageAPIKey: "image-key"})
+	if err == nil {
+		t.Fatal("expected an unknown provider error")
+	}
+	var cfgErr *config.ConfigError
+	if !errors.As(err, &cfgErr) {
+		t.Fatalf("error %v is not a *config.ConfigError", err)
+	}
+	if !strings.Contains(cfgErr.Hint, "minimax") {
+		t.Fatalf("unknown provider hint = %q, must list minimax", cfgErr.Hint)
 	}
 }

--- a/internal/image/minimax_test.go
+++ b/internal/image/minimax_test.go
@@ -285,6 +285,7 @@ func TestMiniMaxMapsAPIStatusCodes(t *testing.T) {
 		{statusCode: 1002, wantCode: "rate_limit"},
 		{statusCode: 1008, wantCode: "payment_required"},
 		{statusCode: 1026, wantCode: "safety_blocked"},
+		{statusCode: 1027, wantCode: "safety_blocked"},
 		{statusCode: 2013, wantCode: "bad_request"},
 		{statusCode: 1039, wantCode: "api_error"},
 	}
@@ -306,6 +307,23 @@ func TestMiniMaxMapsAPIStatusCodes(t *testing.T) {
 				t.Fatalf("error message %q must preserve the upstream status code", genErr.Message)
 			}
 		})
+	}
+}
+
+func TestMiniMaxMapsSensitiveOutputStatus(t *testing.T) {
+	provider := newTestMiniMaxProvider(t, &config.Config{ImageAPIKey: "image-key"}, func(*http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusOK, `{"base_resp":{"status_code":1027,"status_msg":"sensitive output"}}`), nil
+	})
+	_, err := provider.Generate(context.Background(), "prompt")
+	genErr := miniMaxGenerateError(t, err)
+	if genErr.Code != "safety_blocked" {
+		t.Fatalf("error code = %q, want safety_blocked", genErr.Code)
+	}
+	if !strings.Contains(genErr.Message, "generated output") {
+		t.Fatalf("error message = %q, want output-specific detail", genErr.Message)
+	}
+	if !strings.Contains(genErr.Hint, "subject") {
+		t.Fatalf("error hint = %q, want subject guidance", genErr.Hint)
 	}
 }
 

--- a/internal/image/minimax_test.go
+++ b/internal/image/minimax_test.go
@@ -1,0 +1,62 @@
+package image
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/geekjourneyx/md2wechat-skill/internal/config"
+)
+
+func TestMiniMaxGenerateWithSubject(t *testing.T) {
+	provider, err := NewMiniMaxProvider(&config.Config{
+		ImageAPIKey: "image-key", ImageAPIBase: "https://api.minimax.test",
+		ImageModel: "image-01", ImageSize: "16:9",
+	})
+	if err != nil {
+		t.Fatalf("NewMiniMaxProvider() error = %v", err)
+	}
+	provider.client = &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.Method != http.MethodPost || request.URL.Path != "/v1/image_generation" {
+			t.Fatalf("unexpected request: %s %s", request.Method, request.URL.Path)
+		}
+		if got := request.Header.Get("Authorization"); got != "Bearer image-key" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		var payload map[string]any
+		if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+			t.Fatal(err)
+		}
+		references, ok := payload["subject_reference"].([]any)
+		if !ok || len(references) != 1 {
+			t.Fatalf("subject_reference = %#v", payload["subject_reference"])
+		}
+		reference := references[0].(map[string]any)
+		if reference["type"] != "character" || reference["image_file"] != "https://cdn.example/portrait.png" {
+			t.Fatalf("subject reference = %#v", reference)
+		}
+		if payload["aspect_ratio"] != "16:9" || payload["model"] != "image-01" {
+			t.Fatalf("payload = %#v", payload)
+		}
+		return jsonResponse(http.StatusOK, `{"data":{"image_urls":["https://cdn.example/result.png"]},"metadata":{"success_count":1,"failed_count":0},"base_resp":{"status_code":0,"status_msg":"success"}}`), nil
+	})}
+
+	result, err := provider.GenerateWithSubject(context.Background(), "Keep the character", "https://cdn.example/portrait.png")
+	if err != nil {
+		t.Fatalf("GenerateWithSubject() error = %v", err)
+	}
+	if result.URL != "https://cdn.example/result.png" || result.Model != "image-01" {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestMiniMaxGenerateRejectsMissingSubject(t *testing.T) {
+	provider, err := NewMiniMaxProvider(&config.Config{ImageAPIKey: "image-key"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := provider.GenerateWithSubject(context.Background(), "prompt", " "); err == nil {
+		t.Fatal("expected missing subject reference error")
+	}
+}

--- a/internal/image/processor.go
+++ b/internal/image/processor.go
@@ -190,6 +190,17 @@ func (p *Processor) GenerateAndUpload(prompt string) (*GenerateAndUploadResult, 
 	return p.generateAndUploadWithProvider(prompt, p.provider)
 }
 
+// GenerateAndUploadWithSubject generates an image guided by a portrait reference.
+func (p *Processor) GenerateAndUploadWithSubject(prompt, subjectReference string) (*GenerateAndUploadResult, error) {
+	provider, ok := p.provider.(SubjectReferenceProvider)
+	if !ok {
+		return nil, fmt.Errorf("configured image provider does not support subject references")
+	}
+	return p.generateAndUploadWithGenerator(prompt, func(ctx context.Context) (*GenerateResult, error) {
+		return provider.GenerateWithSubject(ctx, prompt, subjectReference)
+	})
+}
+
 // GenerateAndUploadWithSize AI 生成指定尺寸的图片并上传
 func (p *Processor) GenerateAndUploadWithSize(prompt string, size string) (*GenerateAndUploadResult, error) {
 	p.log.Info("generating image via AI with size",
@@ -212,15 +223,25 @@ func (p *Processor) GenerateAndUploadWithSize(prompt string, size string) (*Gene
 }
 
 func (p *Processor) generateAndUploadWithProvider(prompt string, provider Provider) (*GenerateAndUploadResult, error) {
+	var generate func(context.Context) (*GenerateResult, error)
+	if provider != nil {
+		generate = func(ctx context.Context) (*GenerateResult, error) {
+			return provider.Generate(ctx, prompt)
+		}
+	}
+	return p.generateAndUploadWithGenerator(prompt, generate)
+}
+
+func (p *Processor) generateAndUploadWithGenerator(prompt string, generate func(context.Context) (*GenerateResult, error)) (*GenerateAndUploadResult, error) {
 	if err := p.cfg.ValidateForImageGeneration(); err != nil {
 		return nil, err
 	}
-	if provider == nil {
+	if generate == nil {
 		return nil, fmt.Errorf("图片生成服务未配置，请检查配置文件中的 api.image_provider 和 api.image_key")
 	}
 
 	ctx := context.Background()
-	result, err := provider.Generate(ctx, prompt)
+	result, err := generate(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("generate image: %w", err)
 	}

--- a/internal/image/provider.go
+++ b/internal/image/provider.go
@@ -3,6 +3,7 @@ package image
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"sort"
 	"strings"
 
@@ -23,9 +24,10 @@ type ProviderMeta struct {
 }
 
 type ProviderModelMeta struct {
-	Name        string `json:"name"`
-	Description string `json:"description,omitempty"`
-	Default     bool   `json:"default,omitempty"`
+	Name                     string `json:"name"`
+	Description              string `json:"description,omitempty"`
+	Default                  bool   `json:"default,omitempty"`
+	SupportsSubjectReference bool   `json:"supports_subject_reference,omitempty"`
 }
 
 var providerRegistry = []ProviderMeta{
@@ -37,7 +39,7 @@ var providerRegistry = []ProviderMeta{
 		DefaultBaseURL: "https://api.minimax.io",
 		DefaultModel:   "image-01",
 		SupportedModels: []ProviderModelMeta{
-			{Name: "image-01", Description: "MiniMax image model", Default: true},
+			{Name: "image-01", Description: "MiniMax image model", Default: true, SupportsSubjectReference: true},
 			{Name: "image-01-live", Description: "MiniMax live image model"},
 		},
 		SupportsSize:             true,
@@ -194,6 +196,90 @@ func ProviderSupportedModelNames(name string) []string {
 	return result
 }
 
+// ProviderSupportsSubjectReference reports whether the provider accepts a
+// subject reference for image-to-image generation.
+func ProviderSupportsSubjectReference(name string) bool {
+	meta, ok := LookupProviderMeta(name)
+	if !ok {
+		return false
+	}
+	return meta.SupportsSubjectReference
+}
+
+// SubjectReferenceProviderNames lists the providers that accept a subject
+// reference for image-to-image generation.
+func SubjectReferenceProviderNames() []string {
+	result := make([]string, 0, len(providerRegistry))
+	for _, meta := range SupportedProviders() {
+		if meta.SupportsSubjectReference {
+			result = append(result, meta.Name)
+		}
+	}
+	return result
+}
+
+// SubjectReferenceModelNames lists the provider models that accept a subject
+// reference.
+func SubjectReferenceModelNames(provider string) []string {
+	meta, ok := LookupProviderMeta(provider)
+	if !ok || !meta.SupportsSubjectReference {
+		return nil
+	}
+	result := make([]string, 0, len(meta.SupportedModels))
+	for _, model := range meta.SupportedModels {
+		if model.SupportsSubjectReference {
+			result = append(result, model.Name)
+		}
+	}
+	return result
+}
+
+// ModelSupportsSubjectReference reports whether the provider and model pair
+// accepts a subject reference. An empty model resolves to the provider default.
+func ModelSupportsSubjectReference(provider, model string) bool {
+	meta, ok := LookupProviderMeta(provider)
+	if !ok || !meta.SupportsSubjectReference {
+		return false
+	}
+	model = strings.TrimSpace(model)
+	if model == "" {
+		model = meta.DefaultModel
+	}
+	for _, candidate := range meta.SupportedModels {
+		if strings.EqualFold(candidate.Name, model) {
+			return candidate.SupportsSubjectReference
+		}
+	}
+	return false
+}
+
+// ValidateSubjectReferenceURL checks that a subject reference is a public
+// HTTP(S) image URL, which is the only form the current contract supports.
+func ValidateSubjectReferenceURL(reference string) error {
+	trimmed := strings.TrimSpace(reference)
+	if trimmed == "" {
+		return fmt.Errorf("subject reference is required")
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return fmt.Errorf("subject reference must be a valid URL: %w", err)
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	if (scheme != "http" && scheme != "https") || parsed.Host == "" {
+		return fmt.Errorf("subject reference must be a public http:// or https:// image URL; inline data URLs and local paths are not supported")
+	}
+	return nil
+}
+
+// SubjectReferenceModelsHint describes which models accept a subject reference.
+func SubjectReferenceModelsHint(provider string) string {
+	models := SubjectReferenceModelNames(provider)
+	if len(models) == 0 {
+		return ""
+	}
+	return "models supporting subject references: " + strings.Join(models, ", ")
+}
+
 func ProviderSupportedModelsHint(name string) string {
 	models := ProviderSupportedModelNames(name)
 	if len(models) == 0 {
@@ -298,7 +384,7 @@ func NewProvider(cfg *config.Config) (Provider, error) {
 		return nil, &config.ConfigError{
 			Field:   "ImageProvider",
 			Message: fmt.Sprintf("未知的图片服务提供者: %s", cfg.ImageProvider),
-			Hint:    "支持的提供者: openai, tuzi, modelscope (或 ms), openrouter (或 or), gemini (或 google), volcengine (或 volc)",
+			Hint:    "支持的提供者: openai, minimax, tuzi, modelscope (或 ms), openrouter (或 or), gemini (或 google), volcengine (或 volc)",
 		}
 	}
 }

--- a/internal/image/provider.go
+++ b/internal/image/provider.go
@@ -10,15 +10,16 @@ import (
 )
 
 type ProviderMeta struct {
-	Name            string              `json:"name"`
-	Aliases         []string            `json:"aliases,omitempty"`
-	Description     string              `json:"description"`
-	RequiredConfig  []string            `json:"required_config,omitempty"`
-	OptionalConfig  []string            `json:"optional_config,omitempty"`
-	DefaultBaseURL  string              `json:"default_base_url,omitempty"`
-	DefaultModel    string              `json:"default_model,omitempty"`
-	SupportedModels []ProviderModelMeta `json:"supported_models,omitempty"`
-	SupportsSize    bool                `json:"supports_size"`
+	Name                     string              `json:"name"`
+	Aliases                  []string            `json:"aliases,omitempty"`
+	Description              string              `json:"description"`
+	RequiredConfig           []string            `json:"required_config,omitempty"`
+	OptionalConfig           []string            `json:"optional_config,omitempty"`
+	DefaultBaseURL           string              `json:"default_base_url,omitempty"`
+	DefaultModel             string              `json:"default_model,omitempty"`
+	SupportedModels          []ProviderModelMeta `json:"supported_models,omitempty"`
+	SupportsSize             bool                `json:"supports_size"`
+	SupportsSubjectReference bool                `json:"supports_subject_reference,omitempty"`
 }
 
 type ProviderModelMeta struct {
@@ -28,6 +29,20 @@ type ProviderModelMeta struct {
 }
 
 var providerRegistry = []ProviderMeta{
+	{
+		Name:           "minimax",
+		Description:    "MiniMax image generation provider",
+		RequiredConfig: []string{"IMAGE_API_KEY"},
+		OptionalConfig: []string{"IMAGE_API_BASE", "IMAGE_MODEL", "IMAGE_SIZE"},
+		DefaultBaseURL: "https://api.minimax.io",
+		DefaultModel:   "image-01",
+		SupportedModels: []ProviderModelMeta{
+			{Name: "image-01", Description: "MiniMax image model", Default: true},
+			{Name: "image-01-live", Description: "MiniMax live image model"},
+		},
+		SupportsSize:             true,
+		SupportsSubjectReference: true,
+	},
 	{
 		Name:           "openai",
 		Description:    "OpenAI-compatible image generation provider",
@@ -198,6 +213,12 @@ type Provider interface {
 	Generate(ctx context.Context, prompt string) (*GenerateResult, error)
 }
 
+// SubjectReferenceProvider supports image generation guided by a portrait reference.
+type SubjectReferenceProvider interface {
+	Provider
+	GenerateWithSubject(ctx context.Context, prompt, subjectReference string) (*GenerateResult, error)
+}
+
 // GenerateResult 图片生成结果
 type GenerateResult struct {
 	URL           string // 生成的图片 URL
@@ -238,6 +259,11 @@ func NewProvider(cfg *config.Config) (Provider, error) {
 	}
 
 	switch providerName {
+	case "minimax":
+		if err := validateMiniMaxConfig(cfg); err != nil {
+			return nil, err
+		}
+		return NewMiniMaxProvider(cfg)
 	case "tuzi":
 		if err := validateTuZiConfig(cfg); err != nil {
 			return nil, err
@@ -275,6 +301,17 @@ func NewProvider(cfg *config.Config) (Provider, error) {
 			Hint:    "支持的提供者: openai, tuzi, modelscope (或 ms), openrouter (或 or), gemini (或 google), volcengine (或 volc)",
 		}
 	}
+}
+
+func validateMiniMaxConfig(cfg *config.Config) error {
+	if cfg.ImageAPIKey == "" {
+		return &config.ConfigError{
+			Field:   "ImageAPIKey",
+			Message: "MiniMax image generation requires an API key",
+			Hint:    "Set api.image_key in the config file or use IMAGE_API_KEY",
+		}
+	}
+	return nil
 }
 
 // validateOpenAIConfig 验证 OpenAI 配置

--- a/platforms/openclaw/md2wechat/SKILL.md
+++ b/platforms/openclaw/md2wechat/SKILL.md
@@ -52,6 +52,12 @@ Run the smallest useful discovery set:
   md2wechat prompts list --kind image --json
   ```
 
+- Subject-reference (image-to-image) capability before using `--subject-reference`:
+  ```bash
+  md2wechat providers show minimax --json
+  ```
+  Read `supports_subject_reference` on the provider and on each entry of `supported_models`. Only the `minimax` provider and its `image-01` model accept `--subject-reference`, and the reference must be a publicly reachable `http(s)` portrait image URL; inline data URLs and local paths are rejected. Unsupported provider/model combinations fail immediately with `CONFIG_INVALID`, so do not retry them as generation failures.
+
 - Title suggestion prompt selection:
   ```bash
   md2wechat prompts list --kind title --json

--- a/skills/md2wechat/SKILL.md
+++ b/skills/md2wechat/SKILL.md
@@ -50,6 +50,12 @@ Run the smallest useful discovery set:
   md2wechat prompts list --kind image --json
   ```
 
+- Subject-reference (image-to-image) capability before using `--subject-reference`:
+  ```bash
+  md2wechat providers show minimax --json
+  ```
+  Read `supports_subject_reference` on the provider and on each entry of `supported_models`. Only the `minimax` provider and its `image-01` model accept `--subject-reference`, and the reference must be a publicly reachable `http(s)` portrait image URL; inline data URLs and local paths are rejected. Unsupported provider/model combinations fail immediately with `CONFIG_INVALID`, so do not retry them as generation failures.
+
 - Title suggestion prompt selection:
   ```bash
   md2wechat prompts list --kind title --json


### PR DESCRIPTION
Reason: Add MiniMax image-to-image generation with character subject references.

This adds the global endpoint by default with a configurable base URL for the China endpoint, registers the current image models, and exposes subject-reference support in provider discovery. The `generate_image` command accepts a public image URL or data URL through `--subject-reference`, sends the documented character reference payload, and validates the returned status and generated URL.

Checks:

- `GOCACHE=/tmp/md2wechat-go-build go test ./internal/image ./cmd/md2wechat`
- `go vet ./...`
- `GOCACHE=/tmp/md2wechat-go-build go test ./...`
- `make quality-gates`
