### PR TITLE
feat(discovery): publish runtime facts contract

### DIFF
--- a/cmd/md2wechat/export_facts.go
+++ b/cmd/md2wechat/export_facts.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	codeFactsExported        = "FACTS_EXPORTED"
+	runtimeFactsSchemaVersion = "v1"
+)
+
+// SourceCommit is injected at build time for release binaries.
+var SourceCommit = "unknown"
+
+type runtimeFacts struct {
+	SchemaVersion string                  `json:"schema_version"`
+	Version       string                  `json:"version"`
+	SourceCommit  string                  `json:"source_commit"`
+	Counts        runtimeFactsCounts      `json:"counts"`
+	SideEffects   runtimeFactsSideEffects `json:"side_effects"`
+}
+
+type runtimeFactsCounts struct {
+	APIThemes            int `json:"api_themes"`
+	RecommendedScenarios int `json:"recommended_scenarios"`
+	RecommendedSyntax    int `json:"recommended_syntax"`
+	RenderSyntax         int `json:"render_syntax"`
+}
+
+type runtimeFactsSideEffects struct {
+	Convert     bool `json:"convert"`
+	CreateDraft bool `json:"create_draft"`
+}
+
+func newFactsCommand() *cobra.Command {
+	factsCmd := &cobra.Command{
+		Use:   "facts",
+		Short: "Inspect release runtime facts",
+	}
+	exportCmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export the release runtime facts contract",
+		Args:  cobra.NoArgs,
+		RunE:  runFactsExport,
+	}
+	factsCmd.AddCommand(exportCmd)
+	return factsCmd
+}
+
+func runFactsExport(cmd *cobra.Command, args []string) error {
+	data, err := buildRuntimeFacts()
+	if err != nil {
+		return wrapCLIError(codeError, err, "build runtime facts")
+	}
+	responseSuccessWith(codeFactsExported, "Runtime facts exported", data)
+	return nil
+}
+
+func buildRuntimeFacts() (runtimeFacts, error) {
+	themes, err := listThemeViews()
+	if err != nil {
+		return runtimeFacts{}, fmt.Errorf("list themes: %w", err)
+	}
+	apiThemeCount := 0
+	for _, theme := range themes {
+		if theme.Type == "api" && theme.Selectable {
+			apiThemeCount++
+		}
+	}
+
+	layout := buildLayoutCapabilityData()
+	available, ok := layout["available"].(bool)
+	if !ok || !available {
+		if message, ok := layout["error"].(string); ok && message != "" {
+			return runtimeFacts{}, fmt.Errorf("load layout catalog: %s", message)
+		}
+		return runtimeFacts{}, fmt.Errorf("load layout catalog")
+	}
+
+	recommendedScenarios, err := runtimeFactsCount(layout, "recommended_scenario_count")
+	if err != nil {
+		return runtimeFacts{}, err
+	}
+	recommendedSyntax, err := runtimeFactsCount(layout, "recommended_syntax_count")
+	if err != nil {
+		return runtimeFacts{}, err
+	}
+	renderSyntax, err := runtimeFactsCount(layout, "render_syntax_count")
+	if err != nil {
+		return runtimeFacts{}, err
+	}
+
+	sourceCommit := strings.TrimSpace(SourceCommit)
+	if sourceCommit == "" {
+		sourceCommit = "unknown"
+	}
+
+	return runtimeFacts{
+		SchemaVersion: runtimeFactsSchemaVersion,
+		Version:       Version,
+		SourceCommit:  sourceCommit,
+		Counts: runtimeFactsCounts{
+			APIThemes:            apiThemeCount,
+			RecommendedScenarios: recommendedScenarios,
+			RecommendedSyntax:    recommendedSyntax,
+			RenderSyntax:         renderSyntax,
+		},
+		SideEffects: runtimeFactsSideEffects{
+			Convert:     false,
+			CreateDraft: true,
+		},
+	}, nil
+}
+
+func runtimeFactsCount(layout map[string]any, key string) (int, error) {
+	value, ok := layout[key].(int)
+	if !ok {
+		return 0, fmt.Errorf("layout discovery %q is missing or invalid", key)
+	}
+	return value, nil
+}

--- a/cmd/md2wechat/export_facts.go
+++ b/cmd/md2wechat/export_facts.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	codeFactsExported        = "FACTS_EXPORTED"
+	codeFactsExported         = "FACTS_EXPORTED"
 	runtimeFactsSchemaVersion = "v1"
 )
 

--- a/cmd/md2wechat/export_facts_test.go
+++ b/cmd/md2wechat/export_facts_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/geekjourneyx/md2wechat-skill/internal/action"
+	"github.com/spf13/cobra"
+)
+
+func TestFactsExportContract(t *testing.T) {
+	oldJSON, oldVersion := jsonOutput, Version
+	oldSourceCommit, oldCfg := SourceCommit, cfg
+	t.Cleanup(func() {
+		jsonOutput = oldJSON
+		Version = oldVersion
+		SourceCommit = oldSourceCommit
+		cfg = oldCfg
+	})
+
+	Version = "3.4.0"
+	SourceCommit = "07fdea284e71ddaf5c6b5311238d7e9c2df3b8af"
+	cfg = nil
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("MD2WECHAT_THEMES_DIR", "")
+	t.Setenv("MD2WECHAT_PROMPTS_DIR", "")
+	t.Setenv("MD2WECHAT_API_KEY", "")
+	t.Setenv("WECHAT_APPID", "")
+	t.Setenv("WECHAT_SECRET", "")
+
+	root := &cobra.Command{Use: "md2wechat", SilenceErrors: true, SilenceUsage: true}
+	root.PersistentFlags().BoolVar(&jsonOutput, "json", false, "Emit machine-readable JSON output")
+	root.AddCommand(newFactsCommand())
+	root.SetArgs([]string{"facts", "export", "--json"})
+
+	stdout := captureStdout(t, func() {
+		if err := root.Execute(); err != nil {
+			t.Fatalf("facts export: %v", err)
+		}
+	})
+
+	var response struct {
+		Success       bool          `json:"success"`
+		Code          string        `json:"code"`
+		SchemaVersion string        `json:"schema_version"`
+		Status        action.Status `json:"status"`
+		Data          struct {
+			SchemaVersion string `json:"schema_version"`
+			Version       string `json:"version"`
+			SourceCommit  string `json:"source_commit"`
+			Counts        struct {
+				APIThemes            int `json:"api_themes"`
+				RecommendedScenarios int `json:"recommended_scenarios"`
+				RecommendedSyntax    int `json:"recommended_syntax"`
+				RenderSyntax         int `json:"render_syntax"`
+			} `json:"counts"`
+			SideEffects struct {
+				Convert     bool `json:"convert"`
+				CreateDraft bool `json:"create_draft"`
+			} `json:"side_effects"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout, &response); err != nil {
+		t.Fatalf("unmarshal response: %v\n%s", err, stdout)
+	}
+
+	if !response.Success || response.Code != "FACTS_EXPORTED" {
+		t.Fatalf("unexpected response status: %#v", response)
+	}
+	if response.SchemaVersion != action.SchemaVersion || response.Status != action.StatusCompleted {
+		t.Fatalf("unexpected envelope: %#v", response)
+	}
+	if response.Data.SchemaVersion != "v1" {
+		t.Fatalf("schema_version = %q, want v1", response.Data.SchemaVersion)
+	}
+	if response.Data.Version != "3.4.0" {
+		t.Fatalf("version = %q, want 3.4.0", response.Data.Version)
+	}
+	if response.Data.SourceCommit != "07fdea284e71ddaf5c6b5311238d7e9c2df3b8af" {
+		t.Fatalf("source_commit = %q", response.Data.SourceCommit)
+	}
+	if response.Data.Counts.APIThemes != 48 {
+		t.Fatalf("api_themes = %d, want 48", response.Data.Counts.APIThemes)
+	}
+	if response.Data.Counts.RecommendedScenarios != 77 {
+		t.Fatalf("recommended_scenarios = %d, want 77", response.Data.Counts.RecommendedScenarios)
+	}
+	if response.Data.Counts.RecommendedSyntax != 56 {
+		t.Fatalf("recommended_syntax = %d, want 56", response.Data.Counts.RecommendedSyntax)
+	}
+	if response.Data.Counts.RenderSyntax != 63 {
+		t.Fatalf("render_syntax = %d, want 63", response.Data.Counts.RenderSyntax)
+	}
+	if response.Data.SideEffects.Convert {
+		t.Fatal("convert side effect must be false")
+	}
+	if !response.Data.SideEffects.CreateDraft {
+		t.Fatal("create_draft side effect must be true")
+	}
+}

--- a/cmd/md2wechat/main.go
+++ b/cmd/md2wechat/main.go
@@ -295,6 +295,7 @@ func rootCommandManifest() []rootCommandEntry {
 		{Command: brandCmd, DiscoveryOrder: 21},
 		{Command: doctorCmd, DiscoveryOrder: 22},
 		{Command: skillsCmd, DiscoveryOrder: 23},
+		{Command: newFactsCommand(), DiscoveryOrder: 26},
 	}
 }
 

--- a/cmd/md2wechat/main.go
+++ b/cmd/md2wechat/main.go
@@ -295,7 +295,7 @@ func rootCommandManifest() []rootCommandEntry {
 		{Command: brandCmd, DiscoveryOrder: 21},
 		{Command: doctorCmd, DiscoveryOrder: 22},
 		{Command: skillsCmd, DiscoveryOrder: 23},
-		{Command: newFactsCommand(), DiscoveryOrder: 26},
+		{Command: newFactsCommand()},
 	}
 }
 

--- a/docs/contracts/runtime-facts.v1.json
+++ b/docs/contracts/runtime-facts.v1.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "v1",
+  "version": "3.4.0",
+  "source_commit": "07fdea284e71ddaf5c6b5311238d7e9c2df3b8af",
+  "counts": {
+    "api_themes": 48,
+    "recommended_scenarios": 77,
+    "recommended_syntax": 56,
+    "render_syntax": 63
+  },
+  "side_effects": {
+    "convert": false,
+    "create_draft": true
+  }
+}


### PR DESCRIPTION
## Summary

Publish a deterministic, machine-readable runtime facts contract from the CLI for the v3.4.0 release baseline.

## Contract

- `md2wechat facts export --json` uses the existing JSON envelope.
- `data` reports `schema_version=v1`, version, source commit, catalog-derived counts, and explicit side-effect boundaries.
- The command is read-only and offline: it has no config pre-run, does not load credentials, call networks, upload assets, or create drafts.
- The checked-in snapshot identifies `v3.4.0@07fdea284e71ddaf5c6b5311238d7e9c2df3b8af`.

## Release integration

Pending explicit approval. The GitHub safety reviewer rejected the scoped `.github/workflows/release.yml` update, even after it was minimized to a pre-build generate/compare gate plus `SourceCommit` ldflag injection. No alternate Git-object bypass was attempted.

The proposed update does not alter the release action or published asset list. It would reject `unknown`, generate the facts payload with version/source ldflags, compare it with the checked-in contract after normalizing only the release commit, and inject the source commit into existing release binary builds.

## Verification

- RED: CI #108 failed as expected because `SourceCommit` was undefined before implementation.
- GREEN: CI #113 completed the unified quality gates successfully, including formatting, vet, lint, all Go tests, npm package validation, and release-check.
- The requested focused `go test -run TestFactsExportContract` was not run separately because the local runtime has no Go toolchain; the full CI test suite included and passed that test.
- `make quality-gates` was not run locally; CI ran its underlying `bash scripts/quality-gates.sh` entry point and reported `quality-gates: OK`.

## Smoke not run

Real renderer/API smoke was not run because this change only exports offline discovery facts and does not alter renderer/API conversion behavior. No remote renderer validation is claimed.